### PR TITLE
Feat/#87 키워드 부스팅 로직 적용

### DIFF
--- a/apps/be/src/learning/sessions/services/sessions-record.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions-record.service.ts
@@ -71,6 +71,7 @@ export class SessionsRecordService {
       const sttResult = await this.sttService.transcribe({
         objectKey,
         language: 'ko-KR',
+        questionId: Number(dto.questionId),
       });
       console.log('[SessionsRecordService] STT result:', sttResult);
 

--- a/apps/be/src/stt/builders/stt-boosting.builder.ts
+++ b/apps/be/src/stt/builders/stt-boosting.builder.ts
@@ -15,7 +15,7 @@ export class SttBoostingBuilder {
   static build(question: QuestionMeta): string[] {
     const keywords: string[] = [];
 
-    question.must_include.forEach((phrase) => {
+    question.mustInclude.forEach((phrase) => {
       keywords.push(...this.expandPhrase(phrase));
     });
 

--- a/apps/be/src/stt/providers/clova-stt.provider.ts
+++ b/apps/be/src/stt/providers/clova-stt.provider.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
-import { SttBoostingBuilder } from '../builders/stt-boosting.builder';
-import { QuestionMeta } from '../types/question-meta.type';
 import axios from 'axios';
 
 @Injectable()
@@ -16,12 +14,7 @@ export class ClovaSttProvider {
     return `${cleanedBase}/${cleanedPath}`;
   }
 
-  async requestSTT(
-    objectKey: string,
-    language: string,
-    questionMeta: QuestionMeta,
-  ): Promise<string> {
-    const boostWords = SttBoostingBuilder.build(questionMeta);
+  async requestSTT(objectKey: string, language: string, boostWords: string[]): Promise<string> {
     console.log('[STT BOOST WORDS]', boostWords);
 
     const url = this.joinUrl(

--- a/apps/be/src/stt/services/stt-question-loader.service.ts
+++ b/apps/be/src/stt/services/stt-question-loader.service.ts
@@ -1,31 +1,33 @@
 import { Injectable } from '@nestjs/common';
 
+import { PrismaService } from '@/infra/database/prisma.service';
+
 import { QuestionMeta } from '../types/question-meta.type';
 
-/**
- * Object Storage에 저장된 질문 메타데이터 로더
- *
- * 역할:
- * - questionId → QuestionMeta 로딩
- * - STT / Builder와 완전히 분리
- */
 @Injectable()
 export class SttQuestionLoaderService {
-  /**
-   * 지금은 MOCK
-   * 나중에 Object Storage SDK로 교체
-   */
-  //TODO: questionKey 파라미터 통해 메타데이터 로딩
-  //async loadQuestionMeta(questionKey: string): Promise<QuestionMeta> {
-  async loadQuestionMeta(): Promise<QuestionMeta> {
-    // TODO : 메타데이터 로딩
-    // 예: questions/os.pt.process_vs_thread.json
+  constructor(private readonly prisma: PrismaService) {}
 
-    // 일단 현재는 MOCK 데이터
+  async loadQuestionMeta(questionId: number): Promise<QuestionMeta> {
+    const question = await this.prisma.question.findUnique({
+      where: { id: questionId },
+      select: {
+        id: true,
+        content: true,
+        topicId: true,
+        mustInclude: true,
+      },
+    });
+
+    if (!question) {
+      throw new Error('Question not found');
+    }
+
     return {
-      prompt: '프로세스와 스레드의 메모리 공유 방식 차이를 설명하시오.',
-      intent: '메모리 공유 방식의 차이점 이해',
-      must_include: ['공유 메모리', '독립적 주소 공간', '상호 배제 문제'],
+      questionId: question.id,
+      content: question.content,
+      topicId: question.topicId,
+      mustInclude: question.mustInclude as string[],
     };
   }
 }

--- a/apps/be/src/stt/services/stt.service.ts
+++ b/apps/be/src/stt/services/stt.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 
+import { SttBoostingBuilder } from '../builders/stt-boosting.builder';
 import { ClovaSttProvider } from '../providers/clova-stt.provider';
 import { SttQuestionLoaderService } from './stt-question-loader.service';
 
@@ -10,22 +11,69 @@ export class SttService {
     private readonly questionLoader: SttQuestionLoaderService,
   ) {}
 
-  // TODO: 여기 ObjectStorage에서 questionKey는 해당 질문 저장 위치!! 따라서 거기 있는지 확인!!
-  //async transcribe(params: { objectKey: string; language: string, questionKey: string; }): Promise<{ text: string }> {
-  async transcribe(params: { objectKey: string; language: string }): Promise<{ text: string }> {
+  async transcribe(params: {
+    objectKey: string;
+    language: string;
+    questionId: number;
+  }): Promise<{ text: string }> {
     try {
-      // TODO: ObjectStorage에 어떻게 질문이 올라가냐에 따라 key 파라미터로 넘겨주기
-      // const questionMeta = await this.questionLoader.loadQuestionMeta(params.questionKey);
-      const questionMeta = await this.questionLoader.loadQuestionMeta();
+      // 1. 메서드 진입
+      console.log('[STT] transcribe start', {
+        objectKey: params.objectKey,
+        language: params.language,
+        questionId: params.questionId,
+        questionIdType: typeof params.questionId,
+      });
+
+      // 2. QuestionMeta 로딩 시작
+      console.log('[STT] loading question meta...');
+      const questionMeta = await this.questionLoader.loadQuestionMeta(params.questionId);
+
+      // 3. QuestionMeta 로딩 완료
+      console.log('[STT] question meta loaded', {
+        questionId: questionMeta.questionId,
+        topicId: questionMeta.topicId,
+        mustInclude: questionMeta.mustInclude,
+        mustIncludeLength: questionMeta.mustInclude?.length,
+      });
+
+      // 4. boostWords 생성
+      const boostWords = SttBoostingBuilder.build(questionMeta);
+      console.log('[STT] boostWords built', {
+        boostWords,
+        boostWordsCount: boostWords.length,
+      });
+
+      // 5. Clova STT 호출 직전
+      console.log('[STT] calling Clova STT', {
+        objectKey: params.objectKey,
+        language: params.language,
+      });
+
       const text = await this.clovaSttProvider.requestSTT(
         params.objectKey,
         params.language,
-        questionMeta,
+        boostWords,
       );
+
+      // 6. Clova STT 응답 수신
+      console.log('[STT] Clova STT success', {
+        textLength: text?.length,
+        textPreview: text?.slice(0, 50),
+      });
 
       return { text };
     } catch (error) {
-      console.error('STT ERROR:', error);
+      // 7. 에러 발생 지점 로그
+      console.error('[STT ERROR] occurred');
+      console.error('[STT ERROR] raw error:', error);
+
+      // axios 에러일 경우 (Clova)
+      if ((error as any)?.response) {
+        console.error('[STT ERROR] Clova response status:', (error as any).response.status);
+        console.error('[STT ERROR] Clova response data:', (error as any).response.data);
+      }
+
       throw new InternalServerErrorException({
         code: 'STT_FAILED',
         message: '음성 인식 처리에 실패했습니다.',

--- a/apps/be/src/stt/types/question-meta.type.ts
+++ b/apps/be/src/stt/types/question-meta.type.ts
@@ -1,5 +1,6 @@
 export type QuestionMeta = {
-  prompt: string;
-  intent: string;
-  must_include: string[];
+  questionId: number;
+  content: string;
+  topicId: string;
+  mustInclude: string[];
 };


### PR DESCRIPTION
## 🔗 관련 이슈

- close #87

<br/>

## 🔍 작업 내용

기존 mock 기반 STT 키워드 부스팅을 제거하고,
질문 메타데이터의 MUST_INCLUDE 키워드를 기반으로 실제 키워드 부스팅 로직을 적용했습니다.

### 1️⃣ STT 요청 시 질문 컨텍스트 전달 구조 개선

  - `questionId`를 STT 진입 시점부터 전달하도록 수정

  - STT 처리 과정에서 질문 메타데이터를 로드할 수 있도록 구조 변경

- 변경 파일

  - `apps/be/src/learning/sessions/services/sessions-record.service.ts`

  - `apps/be/src/stt/services/stt.service.ts`

### 2️⃣ QuestionMeta 로딩 로직 실제 구현

  - 기존 mock 형태의 메타데이터 로딩 제거

  - Prisma를 통해 DB에서 질문 메타데이터 조회

  - `mustInclude` 필드를 실제 데이터 기반으로 사용

- 변경 파일

  - `apps/be/src/stt/services/stt-question-loader.service.ts`

  - `apps/be/src/stt/types/question-meta.type.ts`

### 3️⃣ MUST_INCLUDE 기반 키워드 부스팅 로직 적용

  - 기존 하드코딩(mock) 방식 제거

  - `QuestionMeta.mustInclude`를 기반으로 부스팅 키워드 생성

  - phrase 확장 로직(expandPhrase)을 통해 STT 부스팅 단어 목록 구성

- 변경 파일

  - `apps/be/src/stt/builders/stt-boosting.builder.ts`

### 4️⃣ Clova STT Provider 인터페이스 정리

  - STT Provider에서 QuestionMeta 의존성 제거

  - 외부 STT 호출은 정제된 boostWords만 받도록 책임 분리

- 변경 파일

  - `apps/be/src/stt/providers/clova-stt.provider.ts`

<br/>

## 📷 스크린샷

- 빌더에 전역 CS 키워드 추가
<img width="1159" height="811" alt="image" src="https://github.com/user-attachments/assets/b60eb6e7-7a79-4ee0-9e92-36a474277281" />


<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
- 리뷰 예상 시간: `3분`
<br/>

## 📄 추가 전달 사항
- 키워드 부스팅 자체는 사용자의 자연어 발음을 그대로 듣고 변환하는 것에 초점을 맞추고 있기 때문에, 각각의 문제에 대해 `must_include`를 이용해서 부스팅하고, 전역적으로 CS 키워드를 중심으로 부스팅을 하더라도, 모든 단어를 잘 인식하지는 못했습니다.

따라서 STT normalize 단계에서 이 부분을 조금 더 정규화해서 LLM으로 넘겨주도록 해야할 것 같습니다.
