### PR TITLE
Feat/#86 다음 질문 제공 API 구현

### DIFF
--- a/apps/be/src/learning/sessions/controllers/sessions.controller.ts
+++ b/apps/be/src/learning/sessions/controllers/sessions.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Param, ParseIntPipe, Post } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBody,
+  ApiNoContentResponse,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -54,5 +56,43 @@ export class SessionsController {
   ) {
     const userId = 1; // TODO: 추후 인증 연동
     return this.sessionsService.createSession(userId, dto);
+  }
+
+  @Post(':sessionId/next-question')
+  @ApiOperation({
+    summary: '다음 질문 제공',
+    description: '진행 중인 학습 세션에서 다음 질문을 제공합니다.',
+  })
+  @ApiParam({
+    name: 'sessionId',
+    description: '학습 세션 ID',
+    type: Number,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '다음 질문 제공 성공',
+    schema: {
+      example: {
+        currentQuestionCount: 3,
+        remainedCredit: 20,
+        question: {
+          questionId: 102,
+          content: 'Deadlock의 발생 조건 4가지를 설명해주세요.',
+          guide: '상호 배제, 점유와 대기, 비선점, 순환 대기를 중심으로 설명하세요.',
+          category: 'OS',
+          difficulty: 'MEDIUM',
+          timeLimit: 300,
+        },
+      },
+    },
+  })
+  @ApiNoContentResponse({
+    description: '더 이상 제공할 질문이 없음',
+  })
+  @ApiBadRequestResponse({
+    description: '유효하지 않은 세션이거나 잔여 크레딧 부족',
+  })
+  async getNextQuestion(@Param('sessionId', ParseIntPipe) sessionId: number) {
+    return this.sessionsService.getNextQuestion(sessionId);
   }
 }

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -1,7 +1,9 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 
+import { Difficulty, Domain } from '@/common/enums/learning.enum';
 import { CreateSessionDto } from '@/learning/sessions/schemas/create-session.schema';
 import { QuestionProviderService } from '@/modules/question-provider/application/question-provider.service';
+import { UserCreditsRepository } from '@/users/credits/user-credits.repository';
 
 import { SessionsRepository } from '../sessions.repository';
 import { GuideBuilderService } from './guide-builder.service';
@@ -12,6 +14,7 @@ export class SessionsService {
     private readonly sessionsRepository: SessionsRepository,
     private readonly questionService: QuestionProviderService,
     private readonly guideBuilder: GuideBuilderService,
+    private readonly userCreditsRepository: UserCreditsRepository,
   ) {}
 
   async createSession(userId: number, dto: CreateSessionDto) {
@@ -26,7 +29,7 @@ export class SessionsService {
     // }
 
     /**
-     * 첫 질문 조회 (mock)
+     * 첫 질문 조회
      */
     const question = await this.questionService.pickOne(dto.category, dto.difficulty);
 
@@ -53,6 +56,108 @@ export class SessionsService {
       sessionId: session.id,
       currentQuestionCount: 1,
       remainedCredit: 20,
+      question: {
+        questionId: question.questionId,
+        content: question.content,
+        guide,
+        category: question.domain,
+        difficulty: question.difficulty,
+        timeLimit: question.timeLimitSec,
+      },
+    };
+  }
+
+  async getNextQuestion(sessionId: number) {
+    /**
+     * 1. 세션 조회
+     */
+    const session = await this.sessionsRepository.findById(sessionId);
+
+    if (!session) {
+      throw new NotFoundException('학습 세션을 찾을 수 없습니다.');
+    }
+
+    /**
+     * 2. 세션 상태 검증
+     */
+
+    if (session.completedAt) {
+      throw new BadRequestException('이미 종료된 학습 세션입니다.');
+    }
+
+    /**
+     * 3. 유저 잔여 크레딧 조회 (UserCredit ledger SUM)
+     */
+    /*const remainedCredit = await this.userCreditsRepository.getTotalCredit(session.userId);
+
+    if (remainedCredit <= 0) {
+      throw new BadRequestException('잔여 크레딧이 부족합니다.');
+    }*/
+
+    const question = await this.questionService.pickOne(
+      session.category as Domain,
+      session.difficulty as Difficulty,
+    );
+
+    if (!question) {
+      /**
+       * 더 이상 질문이 없다면 세션 종료 처리
+       */
+      /**
+       * TODO: 세션 종료 처리
+       *
+       * - status를 COMPLETED로 변경
+       * - completedAt 기록
+       * - 최종 점수 / XP 계산 (향후)
+       * - 세션 요약 리포트 생성 (향후)
+       * - 더이상 질문이 없다는 건, 알려줘야하지 않을까?
+       */
+    }
+
+    /**
+     * 5. 답변 가이드 생성
+     */
+    const guide = this.guideBuilder.build(question.mustInclude);
+
+    /**
+     * 6. 세션 진행 + 크레딧 차감 (트랜잭션 권장)
+     */
+    await this.sessionsRepository.transaction(async (tx) => {
+      // 질문 개수 증가
+      await tx.session.update({
+        where: { id: session.id },
+        data: {
+          currentQuestionCount: {
+            increment: 1,
+          },
+        },
+      });
+
+      /**
+       * TODO: 크레딧 차감 처리
+       *
+       * - UserCredit ledger에 차감 row 추가 (amount: -1)
+       * - reason: 'SESSION_QUESTION'
+       *
+       * - 반드시 세션 진행(currentQuestionCount 증가)과
+       *   동일 트랜잭션으로 처리할 것
+       *
+       * - 트랜잭션 내부에서:
+       *   1) 현재 유저 총 크레딧 재조회 (SUM)
+       *   2) 크레딧 부족 시 rollback
+       *
+       * - 중복 요청(빠른 연속 호출) 방어 필요
+       *   - idempotency key 또는
+       *   - (sessionId, questionIndex) 기준 중복 차감 방지
+       */
+    });
+
+    /**
+     * 7. 응답 반환
+     */
+    return {
+      currentQuestionCount: session.currentQuestionCount + 1,
+      remainedCredit: 20, //TODO 크레딧 차감, 예시 : remainedCredit - 1,
       question: {
         questionId: question.questionId,
         content: question.content,

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -120,44 +120,11 @@ export class SessionsService {
     const guide = this.guideBuilder.build(question.mustInclude);
 
     /**
-     * 6. 세션 진행 + 크레딧 차감 (트랜잭션 권장)
-     */
-    await this.sessionsRepository.transaction(async (tx) => {
-      // 질문 개수 증가
-      await tx.session.update({
-        where: { id: session.id },
-        data: {
-          currentQuestionCount: {
-            increment: 1,
-          },
-        },
-      });
-
-      /**
-       * TODO: 크레딧 차감 처리
-       *
-       * - UserCredit ledger에 차감 row 추가 (amount: -1)
-       * - reason: 'SESSION_QUESTION'
-       *
-       * - 반드시 세션 진행(currentQuestionCount 증가)과
-       *   동일 트랜잭션으로 처리할 것
-       *
-       * - 트랜잭션 내부에서:
-       *   1) 현재 유저 총 크레딧 재조회 (SUM)
-       *   2) 크레딧 부족 시 rollback
-       *
-       * - 중복 요청(빠른 연속 호출) 방어 필요
-       *   - idempotency key 또는
-       *   - (sessionId, questionIndex) 기준 중복 차감 방지
-       */
-    });
-
-    /**
-     * 7. 응답 반환
+     * 6. 응답 반환
      */
     return {
-      currentQuestionCount: session.currentQuestionCount + 1,
-      remainedCredit: 20, //TODO 크레딧 차감, 예시 : remainedCredit - 1,
+      currentQuestionCount: session.currentQuestionCount,
+      remainedCredit: 20,
       question: {
         questionId: question.questionId,
         content: question.content,

--- a/apps/be/src/learning/sessions/sessions.module.ts
+++ b/apps/be/src/learning/sessions/sessions.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { QuestionProviderModule } from '@/modules/question-provider/question-provider.module';
+import { UsersModule } from '@/users/users.module';
 
 import { DatabaseModule } from '../../infra/database/database.module';
 import { ClovaSttProvider } from '../../stt/providers/clova-stt.provider';
@@ -14,7 +15,7 @@ import { SessionsService } from './services/sessions.service';
 import { SessionsRepository } from './sessions.repository';
 
 @Module({
-  imports: [DatabaseModule, SttModule, QuestionProviderModule],
+  imports: [DatabaseModule, SttModule, QuestionProviderModule, UsersModule],
   controllers: [SessionsRecordController, SessionsController],
   providers: [
     SessionsRecordService,

--- a/apps/be/src/learning/sessions/sessions.repository.ts
+++ b/apps/be/src/learning/sessions/sessions.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { Prisma } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 import { PrismaService } from '../../infra/database/prisma.service';
 
@@ -137,5 +137,16 @@ export class SessionsRepository {
       where: { id },
       data,
     });
+  }
+
+  /**
+   * Prisma 트랜잭션 래퍼
+   *
+   * - Service 레이어에서 트랜잭션 경계를 명확히 하기 위함
+   * - 현재는 세션 진행용으로 사용
+   * - 내부 로직은 추후 확장 가능
+   */
+  async transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
+    return this.prisma.$transaction(fn);
   }
 }

--- a/apps/be/src/users/credits/user-credits.repository.ts
+++ b/apps/be/src/users/credits/user-credits.repository.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '@/infra/database/prisma.service';
+
+@Injectable()
+export class UserCreditsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 유저의 현재 총 크레딧 조회 (append-only ledger 구조)
+   *
+   * 동기화 불일치 문제 차단 위함.
+   */
+  async getTotalCredit(userId: number): Promise<number> {
+    const result = await this.prisma.userCredit.aggregate({
+      where: { userId },
+      _sum: { amount: true },
+    });
+
+    return result._sum.amount ?? 0;
+  }
+
+  /**
+   * 유저 크레딧 차감
+   * 크레딧 차감은 기존 row를 수정하지 않고
+   * 새로운 row를 추가하는 방식으로 처리
+   *
+   * amount는 항상 음수(-)로 저장
+   */
+  async consume(userId: number, reason: string, amount: number = 1) {
+    return this.prisma.userCredit.create({
+      data: {
+        userId,
+        amount: -amount,
+        reason,
+      },
+    });
+  }
+}

--- a/apps/be/src/users/users.module.ts
+++ b/apps/be/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { UserCreditsRepository } from './credits/user-credits.repository';
+
+@Module({
+  providers: [UserCreditsRepository],
+  exports: [UserCreditsRepository],
+})
+export class UsersModule {}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #86

<br/>

## 🔍 작업 내용

### 1. 세션 다음 질문 제공 API 추가

#### 📄 `learning/sessions/controllers/sessions.controller.ts`
- `POST /api/learning/sessions/:sessionId/next-question` 엔드포인트 추가
- `sessionId` path param에 `ParseIntPipe` 적용
- 컨트롤러는 요청 위임 역할만 수행하도록 유지

---

#### 📄 `learning/sessions/services/sessions.service.ts`
- `getNextQuestion(sessionId)` 메서드 추가
- 세션 조회 및 상태 검증 로직 구현
- 세션에 설정된 `category / difficulty` 기반으로 다음 질문 선택
- 질문 제공 시 `currentQuestionCount` 증가 처리
- **세션 종료 / 크레딧 차감 로직은 이번 스코프에서 제외하고 TODO로 명시**

---

### 2. SessionsRepository 확장

#### 📄 `learning/sessions/sessions.repository.ts`
- `findById(sessionId)` 메서드 추가
- Prisma `$transaction`을 감싼 `transaction()` 메서드 추가
  - Service 레벨에서 트랜잭션 경계를 명확히 하기 위함
  - 현재는 질문 개수 증가 처리만 포함

---

### 3. UserCredit 도메인 분리 및 구조 선반영

#### 📄 `users/credits/user-credits.repository.ts`
- UserCredit 테이블을 **ledger(원장) 패턴**으로 사용하는 Repository 추가
- 유저 크레딧 총합 조회 (`SUM(amount)`)
- 크레딧 차감 row insert를 위한 메서드 정의

> ⚠️ 이번 작업에서는 실제 크레딧 차감 로직은 연결하지 않음  
> 구조만 선반영한 상태

---

#### 📄 `users/users.module.ts`
- `UserCreditsRepository` provider 등록
- SessionsModule에서 사용 가능하도록 export 처리

---

### 4. SessionsModule 의존성 연결

#### 📄 `learning/sessions/sessions.module.ts`
- `UsersModule` import
- SessionsService에서 `UserCreditsRepository` 주입 가능하도록 구성

<br/>

## 📷 스크린샷

- API 동작은 Swagger로 수동 테스트
<img width="1331" height="905" alt="image" src="https://github.com/user-attachments/assets/9a7e11a7-24cc-487f-811c-d6d3d067cdaf" />


<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
- 리뷰 예상 시간: `10분`

<br/>

## 📄 추가 전달 사항
### 💳 크레딧(UserCredit) 관련 설계 및 TODO 설명

이번 작업에서는 **크레딧 도메인의 “구조만” 선반영**했습니다.

> `UserCredit`는 **ledger(원장) 방식**으로 관리 -> 기획대로!
> 증가/차감 모두 row insert 방식

#### ✔️ 현재까지 구현된 범위
  - 현재 크레딧은 `SUM(amount)`으로 계산
- `UserCreditsRepository`에서:
  - 총 크레딧 조회
  - 차감 row 생성 메서드 정의

#### ❗ 이번 스코프에서 제외한 부분 (TODO)
- 세션 진행 시 크레딧 차감
- 트랜잭션 내부에서의 크레딧 재검증
- 중복 요청(빠른 연속 호출) 방어

#### 🔜 추후 연동 방식 (예정)
- `SessionsService.getNextQuestion()` 내 트랜잭션에서:
  1. 유저 크레딧 총합 재조회
  2. 부족 시 rollback
  3. 질문 제공과 동시에 크레딧 차감 row insert
- 세션 종료 시점에 따른 추가 정책은 별도 논의 예정

> 크레딧은 재화 성격이 강해 **동기화 이슈를 피하기 위해 total 컬럼 없이 ledger 방식**을 채택했습니다.

---

### 📌 세션 종료 관련 TODO

- `status = COMPLETED` 와 `completedAt`은 **항상 함께 관리되어야 함**
- 현재는 종료 정책이 확정되지 않아 로직 구현을 의도적으로 보류
- 추후 `finishSession()` 단일 경로로 종료 처리 예정
