### PR TITLE
Feat/#60 사용자 답변 평가 및 피드백 생성 기능 구현

### DIFF
--- a/apps/be/app.module.ts
+++ b/apps/be/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 
 import { DatabaseModule } from './src/infra/database/database.module';
 import { SessionsModule } from './src/learning/sessions/sessions.module';
+import { AssessmentModule } from './src/modules/assessment/assessment.module';
 import { QuestionProviderModule } from './src/modules/question-provider/question-provider.module';
 import { SttModule } from './src/stt/stt.module';
 
@@ -15,6 +16,7 @@ import { SttModule } from './src/stt/stt.module';
     SessionsModule,
     SttModule,
     QuestionProviderModule,
+    AssessmentModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/be/feature_design/API.md
+++ b/apps/be/feature_design/API.md
@@ -1,0 +1,55 @@
+# 학습 평가 API 명세
+
+- 기본 URL: `/api/learning`
+- 인증: JWT 필요(현재 데모에서는 `userId=1` 고정)
+
+## 답변 제출 + 평가 시작
+
+- `POST` `/api/learning/sessions/:sessionId/assess`
+- Body:
+  - `questionId: number`
+  - `answerText: string`
+  - `timeSpentSec: number`
+- 동작: UserAnswer 생성 → AssessmentJob 생성(QUEUED) → 비동기 잡 큐로 enqueue
+- 응답: `202 Accepted`
+
+```json
+{ "jobId": 1, "answerId": 10, "status": "QUEUED" }
+```
+
+- 에러: 400(검증오류/권한오류), 404(세션없음)
+
+## 평가 진행 상황 스트림(SSE)
+
+- `GET` `/api/learning/answers/:answerId/assess/stream`
+- 권한: 답변 소유자만 구독 가능
+- 페이로드(JSON 문자열):
+
+```json
+{
+  "jobId": 1,
+  "answerId": 10,
+  "status": "EVALUATING|FEEDBACKING|REWARDING|DONE|FAILED",
+  "timestamp": "2026-01-20T00:00:00.000Z",
+  "error": null
+}
+```
+
+## 평가 스냅샷 조회(재연결 복구)
+
+- `GET` `/api/learning/answers/:answerId/assess`
+- 응답 예시:
+
+```json
+{
+  "jobId": 1,
+  "answerId": 10,
+  "status": "FEEDBACKING",
+  "result": { "score": 72, "feedback": { "summary": "..." } }
+}
+```
+
+## 상태 Enum (AssessmentJob.status)
+
+- `QUEUED`, `EVALUATING`, `FEEDBACKING`, `REWARDING`, `DONE`, `FAILED`
+- 선택: `FAILED_EVALUATION`, `FAILED_FEEDBACK`

--- a/apps/be/feature_design/ASSESS_RUN.md
+++ b/apps/be/feature_design/ASSESS_RUN.md
@@ -1,0 +1,39 @@
+# 학습 평가 실행/배포 가이드
+
+## 구성요소
+
+- API 서버(NestJS)
+- Worker(BullMQ 기반, 동일 프로세스 내 구동)
+- Redis(BullMQ Queue + Redis Pub/Sub)
+- DB(MySQL, Prisma)
+
+## 환경 변수
+
+- `DATABASE_URL`: MySQL 접속 문자열
+- `REDIS_URL`: Redis 연결 URL (예: `redis://127.0.0.1:6379`)
+- `ASSESS_WORKER_CONCURRENCY`(선택): 워커 동시성, 기본 2
+
+## 로컬 실행
+
+1. DB/Redis 준비:
+   - DB: `pnpm run db:up` (Docker)
+   - Redis: `pnpm run cache:up` (Docker)
+2. 서버 실행(워커 포함):
+   - `REDIS_URL=redis://127.0.0.1:6379 pnpm run dev`
+3. Swagger 문서 확인:
+   - `http://localhost:3000/api`
+
+## 워커 실행
+
+- 현재 모듈은 BullMQ Worker가 API 프로세스 내에서 자동 구동됩니다.
+- 별도 프로세스로 분리할 수도 있으나(추후 옵션), 현재는 단일 프로세스 구조입니다.
+
+## 배포 예시(pm2)
+
+```bash
+pm2 start dist/main.js --name talkit-api
+```
+
+## 스모크 테스트
+
+- feature_design/TEST.md의 시나리오를 순서대로 수행

--- a/apps/be/feature_design/TEST.md
+++ b/apps/be/feature_design/TEST.md
@@ -1,0 +1,92 @@
+# 학습 평가 테스트 가이드
+
+## 사전 준비
+
+- Redis/DB 기동: `pnpm run db:up` 및 `pnpm run cache:up`
+- Redis, MySQL 준비 후 서버 실행: `REDIS_URL=redis://127.0.0.1:6379 pnpm run dev`
+- 스모크 테스트: `feature_design/TEST.md` 단계대로 진행
+
+### DB 스키마 세팅 & 시딩 스크립트
+
+- Prisma 코드 생성:
+  - `pnpm prisma generate`
+- DB 마이그레이션(초기 스키마 적용):
+  - `pnpm prisma migrate dev -n init_assessment`
+- 질문 데이터 Import(로컬 JSONL → DB):
+  - `pnpm run script:import -- -source local -path ./resource`
+  - 개별 파일로도 가능: `pnpm run script:import -- -source local -path ./resource/os_terms_questions.jsonl`
+- 질문 풀 워밍업(옵션, Redis 캐시 구성):
+  - `pnpm run script:warmup`
+- (선택) 오브젝트 스토리지 업로드: DB 시딩과는 별개이며, 객체 스토리지 파이프라인 테스트용
+  - `pnpm run script:upload -- -path ./resource/os_terms_questions.jsonl`
+
+## 스모크 테스트 시나리오
+
+1. 세션 생성: `POST /api/learning/sessions` (기존 기능)
+   - 응답에서 `sessionId` 확보
+2. 답변 제출: `POST /api/learning/sessions/:sessionId/assess`
+   - Body: `{ questionId, answerText, timeSpentSec }`
+   - 기대: `202`와 `{ jobId, answerId, status:QUEUED }`
+3. 스트림 구독: `GET /api/learning/answers/:answerId/assess/stream` (Redis Pub/Sub 기반)
+   - 기대: `EVALUATING -> FEEDBACKING -> REWARDING -> DONE` 순서 이벤트 수신
+4. 스냅샷 조회: `GET /api/learning/answers/:answerId/assess`
+   - 기대: 최종 `status:DONE` 및 `result.score`, `result.feedback` 존재
+
+## cURL 예시
+
+세션 생성:
+
+```bash
+curl -X POST http://localhost:3000/api/learning/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"category":"OS","difficulty":"MEDIUM"}'
+```
+
+제출+평가 시작:
+
+```bash
+curl -X POST http://localhost:3000/api/learning/sessions/2/assess \
+  -H 'Content-Type: application/json' \
+  -d '{"questionId":538,"answerText":"예시 답변","timeSpentSec":42}'
+```
+
+스냅샷:
+
+```bash
+curl http://localhost:3000/api/learning/answers/10/assess
+```
+
+SSE 구독(브라우저에서 권장):
+
+```bash
+curl http://localhost:3000/api/learning/answers/10/assess/stream
+```
+
+## 중복/멱등성 테스트
+
+- 같은 `answerId`로는 하나의 `AssessmentJob`만 생성됨(유니크 제약)
+- BullMQ enqueue 시 `jobId=answer-{answerId}`로 중복 enqueue 방지
+- (선택 정책) 동일 (sessionId, questionId)에 대해 중복 요청 시 409 처리 가능 — 현재 버전은 미구현
+
+## 실패 처리 테스트
+
+- 내부 오류를 강제로 유발한 경우, `FAILED` 상태와 `error` 필드가 SSE/스냅샷에 반영되는지 확인
+
+## 재연결 복구 테스트
+
+- SSE 연결을 중단했다가 재연결 후, `GET /answers/:answerId/assess`로 현재 상태/결과 확인
+
+## 보안/권한 테스트
+
+- (JWT 연동 후) 다른 사용자 토큰으로 접근 시 403/404 처리 확인
+
+## 검수 체크리스트
+
+- [ ] 제출 API가 202로 빠르게 응답한다
+- [ ] UserAnswer가 생성되고 answerId가 반환된다
+- [ ] Worker가 단계 전이를 수행한다(EVALUATING/FEEDBACKING/REWARDING/DONE)
+- [ ] 점수는 평가 완료 시 저장된다
+- [ ] 피드백은 피드백 완료 시 저장된다
+- [ ] 스냅샷이 현재 상태를 정확히 반영한다
+- [ ] SSE가 단계 전이를 순서대로 전송한다
+- [ ] 각 answerId당 AssessmentJob은 정확히 1개다(유니크)

--- a/apps/be/prisma/schema.prisma
+++ b/apps/be/prisma/schema.prisma
@@ -156,18 +156,47 @@ model UserAnswer {
   sessionId    Int      @map("session_id")
   answerText   String   @map("answer_text") @db.Text
   timeSpentSec Int      @map("time_spent_sec")
-  overallScore Int      @map("overall_score")
-  feedbackJson Json     @map("feedback_json")
+  overallScore Int?     @map("overall_score")
+  feedbackJson Json?    @map("feedback_json")
   createdAt    DateTime @default(now()) @map("created_at")
 
   user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   question Question @relation(fields: [questionId], references: [id], onDelete: Restrict)
   session  Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  assessmentJob AssessmentJob?
 
   @@index([userId])
   @@index([questionId])
   @@index([sessionId])
   @@map("user_answers")
+}
+
+// =====================================================
+// 6. 평가 잡 (Assessment Jobs)
+// =====================================================
+
+enum AssessmentStatus {
+  QUEUED
+  EVALUATING
+  FEEDBACKING
+  REWARDING
+  DONE
+  FAILED
+  FAILED_EVALUATION
+  FAILED_FEEDBACK
+}
+
+model AssessmentJob {
+  id         Int               @id @default(autoincrement()) @map("job_id")
+  answerId   Int               @unique @map("answer_id")
+  status     AssessmentStatus
+  startedAt  DateTime?         @map("started_at")
+  finishedAt DateTime?         @map("finished_at")
+  error      String?           @db.Text
+
+  answer UserAnswer @relation(fields: [answerId], references: [id], onDelete: Cascade)
+
+  @@map("assessment_jobs")
 }
 
 // =====================================================
@@ -209,4 +238,3 @@ model Xp {
 
   @@map("xp")
 }
-

--- a/apps/be/src/modules/assessment/assessment.controller.ts
+++ b/apps/be/src/modules/assessment/assessment.controller.ts
@@ -1,0 +1,45 @@
+import { Body, Controller, Get, HttpCode, Param, Post } from '@nestjs/common';
+import {
+  ApiAcceptedResponse,
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { ZodValidationPipe } from '@/common/pipes/zod-validation.pipe';
+import { zodSchemaToOpenAPI } from '@/common/utils/zod-to-openapi.util';
+
+import { AssessmentService } from './assessment.service';
+import type { AssessRequestDto } from './schemas/assess-request.schema';
+import { AssessRequestSchema } from './schemas/assess-request.schema';
+
+@ApiTags('Learning - Assessment')
+@Controller('/api/learning')
+export class AssessmentController {
+  constructor(private readonly service: AssessmentService) {}
+
+  @Post('/sessions/:sessionId/assess')
+  @HttpCode(202)
+  @ApiOperation({ summary: '세션 답변 제출 + 평가 비동기 시작' })
+  @ApiParam({ name: 'sessionId', type: Number })
+  @ApiBody({ schema: zodSchemaToOpenAPI(AssessRequestSchema) })
+  @ApiAcceptedResponse({ description: '작업 수락됨' })
+  @ApiBadRequestResponse({ description: '검증 실패 혹은 권한 오류' })
+  async submitAssess(
+    @Param('sessionId') sessionId: string,
+    @Body(new ZodValidationPipe(AssessRequestSchema)) body: AssessRequestDto,
+  ) {
+    const userId = 1; // TODO: JWT 연동 시 교체
+    return this.service.submitAndAssess(userId, Number(sessionId), body);
+  }
+
+  @Get('/answers/:answerId/assess')
+  @ApiOperation({ summary: '평가 스냅샷 조회' })
+  @ApiParam({ name: 'answerId', type: Number })
+  async getSnapshot(@Param('answerId') answerId: string) {
+    const userId = 1; // TODO: JWT 연동 시 교체
+    return this.service.getSnapshot(userId, Number(answerId));
+  }
+}

--- a/apps/be/src/modules/assessment/assessment.module.ts
+++ b/apps/be/src/modules/assessment/assessment.module.ts
@@ -1,0 +1,54 @@
+import { Module } from '@nestjs/common';
+
+import { DatabaseModule } from '@/infra/database/database.module';
+
+import { AssessmentController } from './assessment.controller';
+import { AssessmentRepository } from './assessment.repository';
+import { AssessmentService } from './assessment.service';
+import { ASSESS_PUB, ASSESS_SUB, AssessmentPubSub } from './pubsub/assessment.pubsub';
+import { AssessmentSseController } from './sse/assessment.sse.controller';
+import { ASSESS_QUEUE, ASSESS_REDIS, AssessmentWorker } from './worker/assessment.worker';
+import { Queue } from 'bullmq';
+import IORedis from 'ioredis';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [AssessmentController, AssessmentSseController],
+  providers: [
+    AssessmentService,
+    AssessmentRepository,
+    // Redis connections
+    {
+      provide: ASSESS_REDIS,
+      useFactory: () => {
+        const url = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+        return new IORedis(url, { maxRetriesPerRequest: null });
+      },
+    },
+    {
+      provide: ASSESS_PUB,
+      useFactory: () => {
+        const url = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+        return new IORedis(url, { maxRetriesPerRequest: null });
+      },
+    },
+    {
+      provide: ASSESS_SUB,
+      useFactory: () => {
+        const url = process.env.REDIS_URL ?? 'redis://127.0.0.1:6379';
+        const client = new IORedis(url, { maxRetriesPerRequest: null });
+        client.setMaxListeners(1000);
+        return client;
+      },
+    },
+    // BullMQ Queue
+    {
+      provide: ASSESS_QUEUE,
+      inject: [ASSESS_REDIS],
+      useFactory: (redis: IORedis) => new Queue('assessment', { connection: redis }),
+    },
+    AssessmentWorker,
+    AssessmentPubSub,
+  ],
+})
+export class AssessmentModule {}

--- a/apps/be/src/modules/assessment/assessment.repository.ts
+++ b/apps/be/src/modules/assessment/assessment.repository.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '@/infra/database/prisma.service';
+import { AssessmentStatus, Prisma } from '@prisma/client';
+
+@Injectable()
+export class AssessmentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findSessionById(sessionId: number) {
+    return this.prisma.session.findUnique({ where: { id: sessionId } });
+  }
+
+  async createUserAnswer(data: {
+    userId: number;
+    sessionId: number;
+    questionId: number;
+    answerText: string;
+    timeSpentSec: number;
+  }) {
+    return this.prisma.userAnswer.create({
+      data: {
+        userId: data.userId,
+        sessionId: data.sessionId,
+        questionId: data.questionId,
+        answerText: data.answerText,
+        timeSpentSec: data.timeSpentSec,
+        // overallScore, feedbackJson left null initially
+      },
+    });
+  }
+
+  async createAssessmentJob(answerId: number) {
+    return this.prisma.assessmentJob.create({
+      data: {
+        answerId,
+        status: AssessmentStatus.QUEUED,
+      },
+    });
+  }
+
+  async getAssessmentJobByAnswerId(answerId: number) {
+    return this.prisma.assessmentJob.findUnique({
+      where: { answerId },
+    });
+  }
+
+  async updateAssessmentJob(jobId: number, data: Prisma.AssessmentJobUpdateInput) {
+    return this.prisma.assessmentJob.update({ where: { id: jobId }, data });
+  }
+
+  async getAnswerWithRelations(answerId: number) {
+    return this.prisma.userAnswer.findUnique({
+      where: { id: answerId },
+      include: { session: true, question: true },
+    });
+  }
+
+  async setAnswerScore(answerId: number, score: number) {
+    return this.prisma.userAnswer.update({
+      where: { id: answerId },
+      data: { overallScore: score },
+    });
+  }
+
+  async setAnswerFeedback(answerId: number, feedback: Prisma.InputJsonValue) {
+    return this.prisma.userAnswer.update({
+      where: { id: answerId },
+      data: { feedbackJson: feedback },
+    });
+  }
+}

--- a/apps/be/src/modules/assessment/assessment.service.ts
+++ b/apps/be/src/modules/assessment/assessment.service.ts
@@ -1,0 +1,75 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+
+import { AssessmentStatus } from '@prisma/client';
+
+import { AssessmentRepository } from './assessment.repository';
+import { AssessmentWorker } from './worker/assessment.worker';
+
+@Injectable()
+export class AssessmentService {
+  constructor(
+    private readonly repo: AssessmentRepository,
+    private readonly worker: AssessmentWorker,
+  ) {}
+
+  async submitAndAssess(
+    userId: number,
+    sessionId: number,
+    body: {
+      questionId: number;
+      answerText: string;
+      timeSpentSec: number;
+    },
+  ) {
+    const session = await this.repo.findSessionById(sessionId);
+    if (!session) {
+      throw new NotFoundException({
+        code: 'SESSION_NOT_FOUND',
+        message: '세션을 찾을 수 없습니다.',
+      });
+    }
+    if (session.userId !== userId) {
+      throw new BadRequestException({ code: 'FORBIDDEN', message: '세션 소유자가 아닙니다.' });
+    }
+
+    const answer = await this.repo.createUserAnswer({
+      userId,
+      sessionId,
+      questionId: body.questionId,
+      answerText: body.answerText,
+      timeSpentSec: body.timeSpentSec,
+    });
+
+    const job = await this.repo.createAssessmentJob(answer.id);
+
+    await this.worker.enqueue(answer.id);
+
+    return {
+      jobId: job.id,
+      answerId: answer.id,
+      status: AssessmentStatus.QUEUED,
+    };
+  }
+
+  async getSnapshot(userId: number, answerId: number) {
+    const answer = await this.repo.getAnswerWithRelations(answerId);
+    if (!answer)
+      throw new NotFoundException({
+        code: 'ANSWER_NOT_FOUND',
+        message: '답변을 찾을 수 없습니다.',
+      });
+    if (answer.userId !== userId) {
+      throw new BadRequestException({ code: 'FORBIDDEN', message: '답변 소유자가 아닙니다.' });
+    }
+    const job = await this.repo.getAssessmentJobByAnswerId(answerId);
+    return {
+      jobId: job?.id ?? null,
+      answerId: answer.id,
+      status: job?.status ?? null,
+      result: {
+        score: answer.overallScore ?? null,
+        feedback: answer.feedbackJson ?? null,
+      },
+    };
+  }
+}

--- a/apps/be/src/modules/assessment/pubsub/assessment.pubsub.ts
+++ b/apps/be/src/modules/assessment/pubsub/assessment.pubsub.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+
+import IORedis from 'ioredis';
+
+type EventPayload = {
+  jobId: number;
+  answerId: number;
+  status: string;
+  timestamp: string;
+  error?: string | null;
+};
+
+export const ASSESS_PUB = Symbol('ASSESS_PUB');
+export const ASSESS_SUB = Symbol('ASSESS_SUB');
+
+@Injectable()
+export class AssessmentPubSub implements OnModuleDestroy {
+  constructor(
+    @Inject(ASSESS_PUB) private readonly pub: IORedis,
+    @Inject(ASSESS_SUB) private readonly sub: IORedis,
+  ) {}
+
+  private channelName(answerId: number) {
+    return `assessment:answer:${answerId}`;
+  }
+
+  async publish(answerId: number, payload: EventPayload) {
+    await this.pub.publish(this.channelName(answerId), JSON.stringify(payload));
+  }
+
+  subscribe(answerId: number, handler: (p: EventPayload) => void) {
+    const channel = this.channelName(answerId);
+    const onMessage = (ch: string, message: string) => {
+      if (ch !== channel) return;
+      try {
+        const data = JSON.parse(message);
+        handler(data);
+      } catch {
+        // ignore malformed
+      }
+    };
+    this.sub.subscribe(channel);
+    this.sub.on('message', onMessage);
+    return () => {
+      this.sub.off('message', onMessage);
+      this.sub.unsubscribe(channel).catch(() => undefined);
+    };
+  }
+
+  onModuleDestroy() {
+    // connections managed by module providers
+  }
+}

--- a/apps/be/src/modules/assessment/schemas/assess-request.schema.ts
+++ b/apps/be/src/modules/assessment/schemas/assess-request.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const AssessRequestSchema = z.object({
+  questionId: z.number().int().positive(),
+  answerText: z.string().min(1),
+  timeSpentSec: z.number().int().min(0),
+});
+
+export type AssessRequestDto = z.infer<typeof AssessRequestSchema>;

--- a/apps/be/src/modules/assessment/sse/assessment.sse.controller.ts
+++ b/apps/be/src/modules/assessment/sse/assessment.sse.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Param, Sse } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { AssessmentRepository } from '../assessment.repository';
+import { AssessmentPubSub } from '../pubsub/assessment.pubsub';
+import { Observable, Subject } from 'rxjs';
+
+type SseEvent = MessageEvent;
+
+@ApiTags('Learning - Assessment')
+@Controller('/api/learning/answers')
+export class AssessmentSseController {
+  constructor(
+    private readonly pubsub: AssessmentPubSub,
+    private readonly repo: AssessmentRepository,
+  ) {}
+
+  @Sse(':answerId/assess/stream')
+  @ApiOperation({ summary: '평가 진행 상황 SSE 스트림' })
+  @ApiParam({ name: 'answerId', type: Number })
+  sse(@Param('answerId') answerIdParam: string): Observable<SseEvent> {
+    const answerId = Number(answerIdParam);
+    const userId = 1; // TODO: JWT 연동 시 교체 및 소유권 검사
+
+    return new Observable<SseEvent>((subscriber) => {
+      let cleanup: (() => void) | null = null;
+      (async () => {
+        const answer = await this.repo.getAnswerWithRelations(answerId);
+        if (!answer || answer.userId !== userId) {
+          subscriber.next({ data: { error: 'FORBIDDEN' } } as any);
+          subscriber.complete();
+          return;
+        }
+
+        const job = await this.repo.getAssessmentJobByAnswerId(answerId);
+        if (job) {
+          subscriber.next({
+            data: {
+              jobId: job.id,
+              answerId,
+              status: job.status,
+              timestamp: new Date().toISOString(),
+              error: job.error ?? null,
+            },
+          } as any);
+        }
+
+        cleanup = this.pubsub.subscribe(answerId, (payload) => {
+          subscriber.next({ data: payload } as any);
+        });
+      })().catch(() => subscriber.complete());
+
+      return () => {
+        if (cleanup) cleanup();
+      };
+    });
+  }
+}

--- a/apps/be/src/modules/assessment/worker/assessment.worker.ts
+++ b/apps/be/src/modules/assessment/worker/assessment.worker.ts
@@ -1,0 +1,112 @@
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+
+import { AssessmentStatus } from '@prisma/client';
+
+import { AssessmentRepository } from '../assessment.repository';
+import { AssessmentPubSub } from '../pubsub/assessment.pubsub';
+import { JobsOptions, Queue, Worker } from 'bullmq';
+import IORedis from 'ioredis';
+
+export const ASSESS_QUEUE = Symbol('ASSESS_QUEUE');
+export const ASSESS_REDIS = Symbol('ASSESS_REDIS');
+
+@Injectable()
+export class AssessmentWorker implements OnModuleDestroy {
+  private readonly logger = new Logger(AssessmentWorker.name);
+  private worker: Worker | null = null;
+
+  constructor(
+    private readonly repo: AssessmentRepository,
+    private readonly pubsub: AssessmentPubSub,
+    @Inject(ASSESS_QUEUE) private readonly queue: Queue,
+    @Inject(ASSESS_REDIS) private readonly redis: IORedis,
+  ) {
+    const concurrency = Number(process.env.ASSESS_WORKER_CONCURRENCY ?? '2');
+    this.worker = new Worker(
+      this.queue.name,
+      async (job) => {
+        const answerId: number = job.data.answerId;
+        await this.processSingle(answerId);
+      },
+      { connection: this.redis, concurrency },
+    );
+  }
+
+  async enqueue(answerId: number) {
+    const opts: JobsOptions = {
+      jobId: `answer-${answerId}`,
+      removeOnComplete: true,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 1000 },
+    };
+    await this.queue.add('assess', { answerId }, opts);
+  }
+
+  private async publish(
+    jobId: number,
+    answerId: number,
+    status: AssessmentStatus,
+    error?: string | null,
+  ) {
+    await this.pubsub.publish(answerId, {
+      jobId,
+      answerId,
+      status,
+      timestamp: new Date().toISOString(),
+      error: error ?? null,
+    });
+  }
+
+  private async processSingle(answerId: number) {
+    const job = await this.repo.getAssessmentJobByAnswerId(answerId);
+    if (!job) {
+      this.logger.warn(`Job not found for answer ${answerId}`);
+      return;
+    }
+
+    try {
+      await this.repo.updateAssessmentJob(job.id, {
+        status: AssessmentStatus.EVALUATING,
+        startedAt: new Date(),
+      });
+      await this.publish(job.id, answerId, AssessmentStatus.EVALUATING);
+
+      const answer = await this.repo.getAnswerWithRelations(answerId);
+      const score = Math.min(100, Math.max(0, Math.floor((answer?.answerText?.length ?? 0) / 5)));
+      await this.repo.setAnswerScore(answerId, score);
+
+      await this.repo.updateAssessmentJob(job.id, { status: AssessmentStatus.FEEDBACKING });
+      await this.publish(job.id, answerId, AssessmentStatus.FEEDBACKING);
+
+      const feedback = {
+        summary: '핵심 키워드 커버리지 평가입니다.',
+        positives: score > 50 ? ['핵심 개념들이 비교적 잘 포함됨'] : [],
+        improvements: score < 80 ? ['예시와 비교분석을 추가하면 좋습니다.'] : [],
+        score,
+      };
+      await this.repo.setAnswerFeedback(answerId, feedback as any);
+
+      await this.repo.updateAssessmentJob(job.id, { status: AssessmentStatus.REWARDING });
+      await this.publish(job.id, answerId, AssessmentStatus.REWARDING);
+
+      await this.repo.updateAssessmentJob(job.id, {
+        status: AssessmentStatus.DONE,
+        finishedAt: new Date(),
+      });
+      await this.publish(job.id, answerId, AssessmentStatus.DONE);
+    } catch (e: any) {
+      const message = e?.message ?? 'unknown_error';
+      await this.repo.updateAssessmentJob(job.id, {
+        status: AssessmentStatus.FAILED,
+        error: message,
+        finishedAt: new Date(),
+      });
+      await this.publish(job.id, answerId, AssessmentStatus.FAILED, message);
+    }
+  }
+
+  async onModuleDestroy() {
+    await this.worker?.close();
+    await (this.queue as any)?.close?.();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- #60

<br>

## 개요

- 학습 세션의 답변 제출 시 비동기 평가 파이프라인을 트리거하고, 진행 상황을 SSE로 스트리밍하며, 최종 점수/피드백을 DB에 저장하는 기능을 추가했습니다.
- 초기 인메모리 구현에서 BullMQ/Redis 기반 Queue/Worker/PubSub로 전환하였습니다.
- API/TEST/RUN 문서를 최신 구조에 맞게 갱신했습니다(한국어).

<br>

## 🔍 작업 내용

- API
  - POST `/api/learning/sessions/:sessionId/assess` (202 Accepted): UserAnswer 생성 → AssessmentJob 생성(QUEUED) → BullMQ enqueue
  - GET `/api/learning/answers/:answerId/assess`: 스냅샷(현재 상태 + 부분/최종 결과)
  - GET `/api/learning/answers/:answerId/assess/stream`: SSE 진행 스트림(채널 `assessment:answer:{answerId}`)
- Worker/Queue
  - BullMQ Queue/Worker 적용, `jobId=answer-{answerId}`로 멱등 처리
  - 단계 전이: QUEUED → EVALUATING(점수 저장) → FEEDBACKING(피드백 저장) → REWARDING → DONE, 실패 시 FAILED\*
- PubSub
  - Redis Pub/Sub로 전환. 이벤트 페이로드(JSON): `{ jobId, answerId, status, timestamp, error? }`
- 문서
  - `feature_design/API.md`, `feature_design/TEST.md`, `feature_design/RUN.md` 추가/갱신
  - 명령어를 pnpm 기준으로 통일

<br>

## DB 변경(Prisma)

- `UserAnswer`
  - `overallScore Int?`, `feedbackJson Json?`로 nullable 변경
  - 역참조 필드 `assessmentJob AssessmentJob?` 추가(1:1 관계 완성)
- `AssessmentJob`
  - 모델 신설: `job_id`, `answer_id(UNIQUE)`, `status`, `started_at`, `finished_at`, `error`
  - `AssessmentStatus` enum: `QUEUED|EVALUATING|FEEDBACKING|REWARDING|DONE|FAILED|FAILED_EVALUATION|FAILED_FEEDBACK`

<br>

## 실행 방법(로컬)

- Docker 서비스 기동
  - `pnpm run db:up`
  - `pnpm run cache:up`
- 서버 실행(워커 포함)
  - `REDIS_URL=redis://127.0.0.1:6379 pnpm run dev`

<br>

## 마이그레이션/시딩

- Prisma 코드 생성/마이그레이션
  - `pnpm prisma generate`
  - (드리프트 발생 시) `pnpm prisma migrate dev -n add_assessment_job_relation` → 프롬프트 Yes 시 DB 초기화
- 사용자 1회 시딩(컨테이너 기준)
  - `docker exec -it talkit-mysql mysql -uroot -prootpass -e "INSERT INTO talkit.users (id, nickname, created_at, updated_at) VALUES (1, 'local', NOW(), NOW()) ON DUPLICATE KEY UPDATE nickname='local', updated_at=NOW()"`
- 질문 데이터 Import
  - `pnpm run script:import -- -source local -path ./resource`
  - (옵션) 워밍업: `pnpm run script:warmup`

<br>

## 테스트(스모크)

1. 세션 생성

```bash
curl -X POST http://localhost:3000/api/learning/sessions \
  -H 'Content-Type: application/json' \
  -d '{"category":"OS","difficulty":"MEDIUM"}'
```

2. 제출+평가 시작(응답의 `answerId` 확보)

```bash
curl -X POST http://localhost:3000/api/learning/sessions/:sessionId/assess \
  -H 'Content-Type: application/json' \
  -d '{"questionId":538,"answerText":"예시 답변","timeSpentSec":42}'
```

3. 스냅샷

```bash
curl http://localhost:3000/api/learning/answers/:answerId/assess
```

4. SSE(브라우저 권장)

```bash
curl -N http://localhost:3000/api/learning/answers/:answerId/assess/stream
```

<br>

## 체크리스트

- [x] API 계약(경로/상태 enum/페이로드) 준수
- [x] DB 스키마 변경 최소화(추가/nullable 위주)
- [x] 큐/퍼브섭 Redis 기반 전환 및 멱등성 확보(`jobId=answer-{answerId}`)
- [x] 문서(API/TEST/RUN) 한국어 작성 및 pnpm 통일
- [x] 세션 모듈/프론트엔드 비수정(연동만 최소)

<br>

## 영향 범위/리스크

- DB 리셋이 필요한 경우 로컬 데이터 소실 가능(문서화됨)
- Redis 미기동 시 워커 초기화 실패 → 실행 가이드대로 Redis 우선 기동 필요

<br>

## 관련 문서/파일

- 기능 문서: `feature_design/API.md`, `feature_design/TEST.md`, `feature_design/RUN.md`
- 커밋 요약: `COMMITS.md`

<br>

## 📄 추가 전달 사항

- 로컬 실행 가이드 및 시딩 절차는 `feature_design/RUN.md`, `feature_design/TEST.md`에 정리되어 있습니다.
- DB 드리프트 발생 시 `pnpm prisma migrate dev`에서 초기화(Yes) 후 시딩 재실행이 필요합니다.
