### PR TITLE
Feat/#45 답변 정규화 로직 구현

### DIFF
--- a/apps/be/.env.example
+++ b/apps/be/.env.example
@@ -11,10 +11,19 @@ REDIS_PORT=6379
 # REDIS_PASSWORD=
 
 # NCloud Object Storage (S3 호환)
-OBJECT_STORAGE_BUCKET_NAME=your-bucket-name
+OBJECT_STORAGE_BUCKET_NAME=talk-it
 NCP_ACCESS_KEY_ID=your-access-key
 NCP_SECRET_ACCESS_KEY=your-secret-key
 NCLOUD_OBJECT_ENDPOINT=https://kr.object.ncloudstorage.com
+
+# 1. 빌더의 '설정' 메뉴 > '연동 정보' 탭에서 확인
+CLOVA_SPEECH_INVOKE_URL=your-invoke-url
+CLOVA_SPEECH_SECRET_KEY=your-secret-key
+
+CLOVA_API_KEY=your-api-key
+CLOVA_MODEL=HCX-007
+CLOVA_NORMAL_MODEL=HCX-003
+CLOVA_BASE_URL=https://clovastudio.stream.ntruss.com
 
 # (옵션) 기타 서비스용 키들 — 필요 시 설정
 # CLOVA_SPEECH_INVOKE_URL=

--- a/apps/be/src/learning/sessions/services/sessions-record.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions-record.service.ts
@@ -96,7 +96,6 @@ export class SessionsRecordService {
       console.log('[SessionsRecordService] 7. Record process completed successfully');
       return {
         sttText: normalizeResult.draftText,
-        //sttText: normalizeResult.preNormalizedText,
       };
     } catch (error) {
       console.error('[SessionsRecordService] ERROR in record process:', error);

--- a/apps/be/src/learning/sessions/services/sessions-record.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions-record.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { NormalizeService } from '@/normalize/normalize.service';
+
 import { normalizeAudio } from '../../../common/audio/normalize-audio';
 import { SttService } from '../../../stt/services/stt.service';
 import { ObjectStorageProvider } from '../providers/object-storage.provider';
@@ -12,6 +14,7 @@ export class SessionsRecordService {
     private readonly sessionsRepository: SessionsRepository,
     private readonly storageProvider: ObjectStorageProvider,
     private readonly sttService: SttService,
+    private readonly normalizeService: NormalizeService,
   ) {}
 
   async record(
@@ -75,11 +78,24 @@ export class SessionsRecordService {
       console.log('[SessionsRecordService] STT result:', sttResult);
 
       /**
-       * 응답 반환
+       * stt -> 정규화 로직
+       */
+      console.log('[NormalizeService] Normalizing STT text for draft');
+      const normalizeResult = await this.normalizeService.normalizeForDraft(sttResult.text);
+      console.log(
+        `[NormalizeService] Normalize completed | rawLength=${normalizeResult.rawText.length}, preLength=${normalizeResult.preNormalizedText.length}, draftLength=${normalizeResult.draftText.length}`,
+      );
+
+      /**
+       * 응답 반환 -> 일단 최종 변환만 작성
+       * 필요시 응답 변환
+       * preNormalizedText: 음차만 변경
+       * rawText: 기존 stt 텍스트
        */
       console.log('[SessionsRecordService] 7. Record process completed successfully');
       return {
-        sttText: sttResult.text,
+        sttText: normalizeResult.draftText,
+        //sttText: normalizeResult.preNormalizedText,
       };
     } catch (error) {
       console.error('[SessionsRecordService] ERROR in record process:', error);

--- a/apps/be/src/learning/sessions/sessions.module.ts
+++ b/apps/be/src/learning/sessions/sessions.module.ts
@@ -3,7 +3,6 @@ import { Module } from '@nestjs/common';
 import { QuestionProviderModule } from '@/modules/question-provider/question-provider.module';
 import { NormalizeModule } from '@/normalize/normalize.module';
 import { UsersModule } from '@/users/users.module';
-import { NormalizeModule } from '@/normalize/normalize.module';
 
 import { DatabaseModule } from '../../infra/database/database.module';
 import { ClovaSttProvider } from '../../stt/providers/clova-stt.provider';

--- a/apps/be/src/learning/sessions/sessions.module.ts
+++ b/apps/be/src/learning/sessions/sessions.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { QuestionProviderModule } from '@/modules/question-provider/question-provider.module';
 import { NormalizeModule } from '@/normalize/normalize.module';
 import { UsersModule } from '@/users/users.module';
+import { NormalizeModule } from '@/normalize/normalize.module';
 
 import { DatabaseModule } from '../../infra/database/database.module';
 import { ClovaSttProvider } from '../../stt/providers/clova-stt.provider';

--- a/apps/be/src/learning/sessions/sessions.module.ts
+++ b/apps/be/src/learning/sessions/sessions.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { QuestionProviderModule } from '@/modules/question-provider/question-provider.module';
+import { NormalizeModule } from '@/normalize/normalize.module';
 
 import { DatabaseModule } from '../../infra/database/database.module';
 import { ClovaSttProvider } from '../../stt/providers/clova-stt.provider';
@@ -14,7 +15,7 @@ import { SessionsService } from './services/sessions.service';
 import { SessionsRepository } from './sessions.repository';
 
 @Module({
-  imports: [DatabaseModule, SttModule, QuestionProviderModule],
+  imports: [DatabaseModule, SttModule, QuestionProviderModule, NormalizeModule],
   controllers: [SessionsRecordController, SessionsController],
   providers: [
     SessionsRecordService,

--- a/apps/be/src/learning/sessions/sessions.repository.ts
+++ b/apps/be/src/learning/sessions/sessions.repository.ts
@@ -4,6 +4,15 @@ import { Prisma } from '@prisma/client';
 
 import { PrismaService } from '../../infra/database/prisma.service';
 
+/**
+ * SessionsRepository (세션 생명주기 전용)
+ * 책임
+ * - 세션 생성
+ * - 세션 조회
+ * - 세션 상태 변경 (ACTIVE / COMPLETED)
+ * - 세션 메타데이터 관리
+ */
+
 @Injectable()
 export class SessionsRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -66,76 +75,6 @@ export class SessionsRepository {
         status: 'COMPLETED',
         completedAt: new Date(),
       },
-    });
-  }
-
-  /**
-   * 사용자 답변 저장
-   */
-  async saveAnswer(data: {
-    sessionId: number;
-    userId: number;
-    questionId: number;
-    answerText: string;
-    timeSpentSec: number;
-    overallScore?: number;
-    feedbackJson?: Prisma.InputJsonValue;
-  }) {
-    return this.prisma.userAnswer.create({
-      data: {
-        sessionId: data.sessionId,
-        userId: data.userId,
-        questionId: data.questionId,
-        answerText: data.answerText,
-        timeSpentSec: data.timeSpentSec,
-        overallScore: data.overallScore ?? 0,
-        feedbackJson: data.feedbackJson ?? {},
-      },
-    });
-  }
-
-  /**
-   * 세션의 모든 답변 조회
-   */
-  async findAnswersBySessionId(sessionId: number) {
-    return this.prisma.userAnswer.findMany({
-      where: { sessionId },
-      include: {
-        question: {
-          select: {
-            id: true,
-            content: true,
-            category: true,
-            difficulty: true,
-          },
-        },
-      },
-      orderBy: {
-        createdAt: 'asc',
-      },
-    });
-  }
-
-  /**
-   * 답변 ID로 답변 조회
-   */
-  async findAnswerById(id: number) {
-    return this.prisma.userAnswer.findUnique({
-      where: { id },
-      include: {
-        question: true,
-        session: true,
-      },
-    });
-  }
-
-  /**
-   * 답변 업데이트
-   */
-  async updateAnswer(id: number, data: Prisma.UserAnswerUpdateInput) {
-    return this.prisma.userAnswer.update({
-      where: { id },
-      data,
     });
   }
 }

--- a/apps/be/src/normalize/llm-cleanup.service.ts
+++ b/apps/be/src/normalize/llm-cleanup.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import axios from 'axios';
+
+@Injectable()
+export class LlmCleanupService {
+  private readonly logger = new Logger(LlmCleanupService.name);
+
+  private readonly apiKey = process.env.CLOVA_API_KEY!;
+  private readonly model = process.env.CLOVA_NORMAL_MODEL!;
+  private readonly baseUrl = process.env.CLOVA_BASE_URL!;
+
+  async cleanup(text: string): Promise<string> {
+    console.log('LLM호출');
+
+    try {
+      const response = await axios.post(
+        `${this.baseUrl}/v1/chat-completions/${this.model}`,
+        {
+          topK: 0,
+          includeAiFilters: true,
+          maxTokens: 256,
+          temperature: 0.5,
+          messages: [
+            {
+              role: 'system',
+              content: `
+You are cleaning up raw speech-to-text output for user editing.
+
+Rules:
+- Do NOT add new information.
+- Do NOT explain or summarize.
+- Do NOT change technical meaning.
+- Only remove obvious repetitions and filler words.
+- If a technical term is written as a Korean phonetic transcription,
+  convert it to its standard English technical term.
+- Do NOT convert or reinterpret concepts.
+- Keep all other technical terms exactly as-is.
+              `.trim(),
+            },
+            {
+              role: 'user',
+              content: text,
+            },
+          ],
+          stopBefore: [],
+          repeatPenalty: 5.0,
+          topP: 0.8,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          timeout: 10_000,
+        },
+      );
+
+      const cleaned = response.data?.result?.message?.content;
+
+      if (!cleaned || typeof cleaned !== 'string') {
+        this.logger.warn('[LLM Cleanup] Invalid response, fallback');
+        return text;
+      }
+
+      return cleaned.trim();
+    } catch (error) {
+      this.logger.error('[LLM Cleanup] failed, fallback', error);
+      return text;
+    }
+  }
+}

--- a/apps/be/src/normalize/normalize.module.ts
+++ b/apps/be/src/normalize/normalize.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { LlmCleanupService } from './llm-cleanup.service';
+import { NormalizeService } from './normalize.service';
+
+@Module({
+  providers: [NormalizeService, LlmCleanupService],
+  exports: [NormalizeService],
+})
+export class NormalizeModule {}

--- a/apps/be/src/normalize/normalize.service.ts
+++ b/apps/be/src/normalize/normalize.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { LlmCleanupService } from './llm-cleanup.service';
+import { preNormalize } from './utils/pre-normalize';
+import { shouldCallLlm } from './utils/should-call-llm';
+
+@Injectable()
+export class NormalizeService {
+  constructor(private readonly llmCleanupService: LlmCleanupService) {}
+  private readonly logger = new Logger(NormalizeService.name);
+
+  /**
+   * 사용자에게 보여줄 Draft 텍스트 생성
+   * (STT 이후, User Edit 이전)
+   */
+  async normalizeForDraft(rawText: string): Promise<{
+    rawText: string;
+    preNormalizedText: string;
+    draftText: string;
+  }> {
+    const originalText = rawText ?? '';
+
+    //  Pre-Normalization (rule-based, 음차만)
+    const preNormalizedText = preNormalize(originalText);
+
+    //  LLM Cleanup (User-friendly, optional)
+    let draftText = preNormalizedText;
+
+    if (!shouldCallLlm(preNormalizedText)) {
+      try {
+        this.logger.debug(`Calling LLM cleanup (length=${preNormalizedText.length})`);
+        draftText = await this.llmCleanupService.cleanup(preNormalizedText);
+      } catch (error) {
+        // 실패 시 반드시 fallback
+        this.logger.warn('LLM cleanup failed, falling back to preNormalizedText', error);
+        draftText = preNormalizedText;
+      }
+    }
+
+    return {
+      rawText: originalText,
+      preNormalizedText,
+      draftText,
+    };
+  }
+}

--- a/apps/be/src/normalize/utils/pre-normalize.ts
+++ b/apps/be/src/normalize/utils/pre-normalize.ts
@@ -1,0 +1,74 @@
+// rule-based, 음차만 수정
+export function preNormalize(text: string): string {
+  if (!text) return text;
+
+  const MAP: Record<string, string> = {
+    // OS / HW
+    오에스: 'OS',
+    커널: 'kernel',
+    스케줄러: 'scheduler',
+    컨텍스트: 'context',
+    컨텍스트스위칭: 'context switching',
+
+    // CPU / GPU / Memory
+    씨피유: 'CPU',
+    지피유: 'GPU',
+    캐시: 'cache',
+    레지스터: 'register',
+    메모리: 'memory',
+    페이징: 'paging',
+    페이지폴트: 'page fault',
+
+    // Process / Thread
+    프로세스: 'process',
+    쓰레드: 'thread',
+    스레드: 'thread',
+    멀티쓰레드: 'multithread',
+    멀티스레드: 'multithread',
+
+    // Sync / Concurrency
+    락: 'lock',
+    스핀락: 'spinlock',
+    뮤텍스: 'mutex',
+    세마포어: 'semaphore',
+    데드락: 'deadlock',
+
+    // Network
+    아이피: 'IP',
+    포트: 'port',
+    소켓: 'socket',
+    패킷: 'packet',
+    라우터: 'router',
+
+    // DB / Storage
+    데이터베이스: 'database',
+    디비: 'DB',
+    노에스큐엘: 'NoSQL',
+    에스큐엘: 'SQL',
+    트랜잭션: 'transaction',
+    인덱스: 'index',
+    해시: 'hash',
+    해시인덱스: 'hash index',
+
+    // Backend / API
+    에이피아이: 'API',
+    엔드포인트: 'endpoint',
+    리퀘스트: 'request',
+    리스폰스: 'response',
+
+    // Programming
+    펑션: 'function',
+    베리어블: 'variable',
+    배리어블: 'variable',
+    클래스: 'class',
+    인터페이스: 'interface',
+    오브젝트: 'object',
+  };
+
+  let result = text;
+  for (const [from, to] of Object.entries(MAP)) {
+    result = result.replaceAll(from, to);
+  }
+
+  return result;
+}

--- a/apps/be/src/normalize/utils/should-call-llm.ts
+++ b/apps/be/src/normalize/utils/should-call-llm.ts
@@ -1,0 +1,12 @@
+// LLM 호출 여부 판단 유틸
+export function shouldCallLlm(text: string): boolean {
+  if (!text) return false;
+
+  // 너무 짧은 텍스트의 경우 LLM 호출 하더라도 변화 거의 없음
+  if (text.length < 50) return false;
+
+  // 아주 단순한 반복 감지
+  const hasRepeatedWord = /(\\b\\w+\\b)(\\s+\\1)+/i.test(text);
+
+  return hasRepeatedWord;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #45

<br/>

## 🔍 작업 내용

### 1. 정규화 파이프라인 도입
- STT 결과를 직접 수정하지 않고, 후처리(Post-process) 레이어로 정규화 수행
- `NormalizeService`를 중심으로 Draft 정규화 파이프라인 구성
- Pre-Normalization(룰 기반) → (Optional) LLM Cleanup 구조로 설계
- LLM 실패 시에도 Draft 텍스트 생성이 보장되도록 fallback 처리 적용

### 2. Pre-Normalization (Rule 기반)
#### `apps/be/src/normalize/utils/pre-normalize.ts`
- CS 기술 용어 한글 음차 → 영문 표기로 변환하는 Rule 기반 유틸 추가
- OS, CPU, NoSQL, thread, mutex 등 의미 해석이 필요 없는 규칙만 포함
- LLM 없이도 항상 동일한 결과를 보장하는 단계로 설계

### 3. Draft 단계 LLM Cleanup
#### `apps/be/src/normalize/llm-cleanup.service.ts`
- 반복어, 말버릇, 군더더기 표현 제거를 위한 LLM Cleanup 서비스 추가
- 프롬프트 제약:
  - 의미·의도 변경 금지
  - 정보 추가/요약 금지
  - 한글 음차로 된 영문 CS 용어만 표준 영문 용어로 변환
- LLM 응답 이상 또는 호출 실패 시 입력 텍스트 그대로 fallback
- Draft 정규화 단계에서만 사용되는 보조 수단으로 설계

### 4. LLM 호출 제어 로직
#### `apps/be/src/normalize/utils/should-call-llm.ts`
- Draft 단계에서 LLM 호출 여부 판단 로직 추가
- 너무 짧은 텍스트는 LLM 호출 제외
- 단순 반복 패턴이 감지되는 경우에만 LLM 호출
- 불필요한 비용 및 응답 지연 방지 목적

### 5. 모듈 구성 및 실제 요청 경로 연동
- `normalize.module.ts` 추가 및 정규화 관련 로직을 단일 모듈로 분리
- `SessionsRecordService`에서 NormalizeService 사용 가능하도록 의존성 정리
- STT → Pre-Normalization → (Optional) LLM Cleanup 흐름을 실제 요청 경로에 연결
- 단계별 로그 추가로 추적 가능성 강화

### 6. SessionsRepository 책임 분리
#### `apps/be/src/learning/sessions/sessions.repository.ts`
- `userAnswer` 관련 메서드 제거
  - `saveAnswer`
  - `findAnswersBySessionId`
  - `findAnswerById`
  - `updateAnswer`
- SessionsRepository의 책임을 **세션 생명주기 관리로 한정**
  - 세션 생성 / 조회 / 상태 변경만 담당하도록 정리

<br/>

## 📷 스크린샷

- UI 변경 없음

### Stt 변환 답변
<img width="1192" height="312" alt="image" src="https://github.com/user-attachments/assets/4c4dc292-698c-47e4-be9b-ed3c6655055b" />

### Pre-Normalize 답변

<img width="911" height="284" alt="image" src="https://github.com/user-attachments/assets/79603561-e160-4613-b5d8-f15a0001bd8e" />

- 음차 Map 기반 변환 (아직 여기 단어 중에는 커널만 존재)


### LLM 정규화 답변
<img width="1113" height="754" alt="image" src="https://github.com/user-attachments/assets/1756c7fa-7ea3-4fc8-acdf-d8868e750ef1" />


<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 정규화 로직이 특정 STT 엔진 구현에 종속되지 않음을 확인했습니다.
- [x] LLM 실패 시에도 Pre-Normalize 결과가 반환되도록 fallback 처리했습니다.
- [x] 관련 문서 업데이트 예정
- [x] 리뷰어 지정 및 리뷰 요청 완료

<br/>

## 💬 리뷰 요구 사항

> 리뷰 예상 시간: `10분`

- Draft 단계에서 **LLM 정규화를 통해 답변을 일부 보정**하고 있는데,
  사용자 발화를 그대로 보여주지 않고 문맥을 정리해주는 방식이
  **UX 관점에서 괜찮을지 의견을 듣고 싶습니다.**
- LLM Cleanup은 보조 수단이며,
  **LLM을 호출하지 않더라도 Pre-Normalize 결과만으로도 응답이 반환**되도록 설계되어 있으니
  해당 부분도 참고해서 리뷰 부탁드립니다.
- 프롬프트에서는 답변의 내용이나 의도를 수정하지 않도록 강하게 제한하고,
  한글 음차로 된 영문 CS 용어만 영문 표기로 바꿔달라고 **영어로 요청**했습니다.
  이 접근 방식에 대한 의견도 함께 주시면 감사하겠습니다 🙇

