### PR TITLE
Feat/#55 학습 세션 종료 api 구현

### DIFF
--- a/apps/be/prisma/schema.prisma
+++ b/apps/be/prisma/schema.prisma
@@ -241,34 +241,6 @@ model AssessmentJob {
 }
 
 // =====================================================
-// 6. 평가 잡 (Assessment Jobs)
-// =====================================================
-
-enum AssessmentStatus {
-  QUEUED
-  EVALUATING
-  FEEDBACKING
-  REWARDING
-  DONE
-  FAILED
-  FAILED_EVALUATION
-  FAILED_FEEDBACK
-}
-
-model AssessmentJob {
-  id         Int               @id @default(autoincrement()) @map("job_id")
-  answerId   Int               @unique @map("answer_id")
-  status     AssessmentStatus
-  startedAt  DateTime?         @map("started_at")
-  finishedAt DateTime?         @map("finished_at")
-  error      String?           @db.Text
-
-  answer UserAnswer @relation(fields: [answerId], references: [id], onDelete: Cascade)
-
-  @@map("assessment_jobs")
-}
-
-// =====================================================
 // 5. 게이미피케이션 (Gamification)
 // =====================================================
 

--- a/apps/be/prisma/schema.prisma
+++ b/apps/be/prisma/schema.prisma
@@ -130,15 +130,16 @@ model Session {
   status               String   @db.VarChar(20)
   totalScore           Int      @default(0) @map("total_score")
   totalTimeSec         Int      @default(0) @map("total_time_sec")
-  gainedXp             Int      @default(0) @map("gained_xp")
+  gainedXp             Json?     @map("gained_xp")
   currentQuestionCount Int      @default(0) @map("current_question_count")
-  category             String   @db.VarChar(50)
+  category             String   @db.VarChar(20)
   difficulty           String   @db.VarChar(20)
   startedAt            DateTime @default(now()) @map("started_at")
   completedAt          DateTime? @map("completed_at")
 
   user    User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   answers UserAnswer[]
+  extraQuestions ExtraQuestion[]
 
   @@index([userId])
   @@index([status])

--- a/apps/be/src/common/utils/date.util.ts
+++ b/apps/be/src/common/utils/date.util.ts
@@ -1,0 +1,15 @@
+export class DateUtil {
+  /** 한국 표준시를 기준으로 날짜(YYYY-MM-DD)를 반환하는 함수 */
+  static getKstDateString(date: Date = new Date()): string {
+    const kstOffset = 9 * 60 * 60 * 1000;
+    return new Date(date.getTime() + kstOffset).toISOString().substring(0, 10);
+  }
+
+  /** 한국 표준시를 기준으로 어제 날짜(YYYY-MM-DD)를 반환하는 함수 */
+  static getYesterdayKstDateString(date: Date = new Date()): string {
+    const kstOffset = 9 * 60 * 60 * 1000;
+    const todayKst = new Date(date.getTime() + kstOffset);
+    todayKst.setDate(todayKst.getDate() - 1);
+    return todayKst.toISOString().substring(0, 10);
+  }
+}

--- a/apps/be/src/learning/sessions/controllers/sessions.controller.ts
+++ b/apps/be/src/learning/sessions/controllers/sessions.controller.ts
@@ -14,6 +14,7 @@ import { zodSchemaToOpenAPI } from '@/common/utils/zod-to-openapi.util';
 
 import { type CreateSessionDto, CreateSessionSchema } from '../schemas/create-session.schema';
 import { type DeepDiveRequestDto, DeepDiveRequestSchema } from '../schemas/deep-dive.schema';
+import { FinishSessionResponseSchema } from '../schemas/finish-session.schema';
 import { DeepDiveService } from '../services/deep-dive.service';
 import { SessionsService } from '../services/sessions.service';
 
@@ -128,5 +129,28 @@ export class SessionsController {
       sessionId,
       answerId: body.answerId,
     });
+  }
+
+  // 세션 종료 요청
+  @Post(':sessionId/finish')
+  @ApiOperation({
+    summary: '학습 세션 종료 및 리워드 정산',
+    description: '세션을 종료하고 획득한 경험치, 레벨 정보, 답변 결과 목록을 반환합니다.',
+  })
+  @ApiParam({
+    name: 'sessionId',
+    description: '종료할 세션 ID',
+    type: Number,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '정산 성공',
+    schema: zodSchemaToOpenAPI(FinishSessionResponseSchema),
+  })
+  @ApiBadRequestResponse({
+    description: '이미 종료된 세션이거나 유효하지 않은 요청',
+  })
+  async finishSession(@Param('sessionId', ParseIntPipe) sessionId: number) {
+    return this.sessionsService.finishSession(sessionId);
   }
 }

--- a/apps/be/src/learning/sessions/schemas/finish-session.schema.ts
+++ b/apps/be/src/learning/sessions/schemas/finish-session.schema.ts
@@ -1,0 +1,46 @@
+import { Difficulty, Domain } from '@/common/enums/learning.enum';
+
+import { z } from 'zod';
+
+// 질문 결과 스키마
+const QuestionResultSchema = z.object({
+  content: z.string().describe('질문 내용'),
+  type: z.enum(['NORMAL', 'TAIL']).describe('질문 유형'),
+  score: z.number().int().min(0).max(100).describe('질문 점수 (0~100)'),
+});
+
+// 획득 경험치 상세 내역 스키마
+const GainedXpDetailSchema = z.object({
+  baseXp: z.number().int().describe('기본 경험치 (답변 점수 합계)'),
+  difficultyBonus: z.number().int().nullable().describe('난이도 보너스'),
+  deepDiveBonus: z.number().int().nullable().describe('심화 학습(꼬리질문) 보너스'),
+});
+
+// 세션 종료 응답 메인 스키마
+export const FinishSessionResponseSchema = z.object({
+  currentXp: z.number().int().describe('현재 경험치 (세션 종료 후)'),
+
+  prevRequiredXpForNextLevel: z
+    .number()
+    .int()
+    .describe('직전 레벨업 요구 경험치 (UI 게이지 시작점용)'),
+
+  requiredXpForNextLevel: z.number().int().describe('다음 레벨업 요구 경험치 (UI 게이지 끝점용)'),
+
+  level: z.number().int().describe('현재 레벨'),
+
+  gainedXp: GainedXpDetailSchema.describe('경험치 획득 상세 내역'),
+
+  category: z.enum(Object.values(Domain) as [Domain, ...Domain[]]).describe('학습 카테고리'),
+
+  difficulty: z
+    .enum(Object.values(Difficulty) as [Difficulty, ...Difficulty[]])
+    .describe('학습 난이도'),
+
+  questions: z.array(QuestionResultSchema).describe('세션에서 답변한 질문 목록'),
+});
+
+// 타입 추출 (DTO)
+export type FinishSessionResponseDto = z.infer<typeof FinishSessionResponseSchema>;
+export type QuestionResultDto = z.infer<typeof QuestionResultSchema>;
+export type GainedXpDetailDto = z.infer<typeof GainedXpDetailSchema>;

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -1,12 +1,27 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 
 import { Difficulty, Domain } from '@/common/enums/learning.enum';
+import { PrismaService } from '@/infra/database/prisma.service';
 import { CreateSessionDto } from '@/learning/sessions/schemas/create-session.schema';
+import { XpRepository } from '@/learning/xp/repository/xp.repository';
 import { QuestionProviderService } from '@/modules/question-provider/application/question-provider.service';
 import { UserCreditsRepository } from '@/users/credits/user-credits.repository';
+import { UserStatsRepository } from '@/users/stats/repository/user-stats.repository';
+import { StreakCalculatorService } from '@/users/stats/services/streak-calculator.service';
+import { XpCalculatorService } from '@/users/stats/services/xp-calculator.service';
+import { Prisma } from '@prisma/client';
 
 import { SessionsRepository } from '../repository/sessions.repository';
+import { FinishSessionResponseDto, GainedXpDetailDto } from '../schemas/finish-session.schema';
 import { GuideBuilderService } from './guide-builder.service';
+
+type TransactionResult = {
+  currentXp: number;
+  level: number;
+  prevRequiredXpForNextLevel: number;
+  requiredXpForNextLevel: number;
+  newStreak: number;
+};
 
 @Injectable()
 export class SessionsService {
@@ -15,6 +30,11 @@ export class SessionsService {
     private readonly questionService: QuestionProviderService,
     private readonly guideBuilder: GuideBuilderService,
     private readonly userCreditsRepository: UserCreditsRepository,
+    private readonly userStatsRepository: UserStatsRepository,
+    private readonly xpRepository: XpRepository,
+    private readonly prisma: PrismaService,
+    private readonly xpCalculator: XpCalculatorService,
+    private readonly streakCalculator: StreakCalculatorService,
   ) {}
 
   async createSession(userId: number, dto: CreateSessionDto) {
@@ -136,6 +156,165 @@ export class SessionsService {
         difficulty: question.difficulty,
         timeLimit: question.timeLimitSec,
       },
+    };
+  }
+
+  /**
+   * 세션 종료 및 리워드(XP, 레벨, 스트릭) 정산을 수행하는 메인 메서드
+   */
+  async finishSession(sessionId: number): Promise<FinishSessionResponseDto> {
+    // 1. 검증 및 데이터 로드
+    const { session, answers } = await this.validateAndLoadSession(sessionId);
+
+    // 2. XP 계산 위임
+    const answersForCalc = answers.map((a) => ({
+      extraQuestionId: a.extraQuestionId ? String(a.extraQuestionId) : null,
+    }));
+    const { totalGainedXp, detail } = this.xpCalculator.calculate(
+      session.difficulty as Difficulty,
+      answersForCalc,
+    );
+
+    // 3. 통계 데이터 집계
+    const totalScore = answers.reduce((sum, ans) => sum + (ans.overallScore || 0), 0);
+    const totalTimeSec = answers.reduce((sum, ans) => sum + (ans.timeSpentSec || 0), 0);
+
+    // 4. DB 트랜잭션 실행
+    const result = await this.prisma.$transaction(async (tx) => {
+      // 4-1. 세션 종료
+      await tx.session.update({
+        where: { id: sessionId, status: 'ACTIVE' },
+        data: {
+          status: 'COMPLETED',
+          completedAt: new Date(),
+          totalScore,
+          totalTimeSec,
+          gainedXp: detail as unknown as Prisma.InputJsonValue,
+        },
+      });
+
+      // 4-2. 유저 스탯 조회
+      const userStats = await this.userStatsRepository.findStatsByUserId(session.userId, tx);
+
+      // 4-3. 스트릭 계산 위임
+      const newStreak = this.streakCalculator.calculate(
+        userStats?.updatedAt,
+        userStats?.streakDays || 0,
+      );
+
+      // 4-4. 누적 데이터 계산
+      const currentLevel = userStats?.level || 1;
+      const currentTotalXp = (userStats?.currentXp || 0) + totalGainedXp;
+
+      // 4-5. 레벨업 처리
+      const levelInfo = await this.processLevelUp(currentLevel, currentTotalXp);
+
+      // 4-6. 유저 스탯 저장
+      await this.userStatsRepository.upsertStats(
+        session.userId,
+        {
+          level: levelInfo.level,
+          currentXp: currentTotalXp, // 누적된 총 XP
+          totalSolvedQuestions: (userStats?.totalSolvedQuestions || 0) + answers.length,
+          streakDays: newStreak,
+          totalStudyTimeSec: (userStats?.totalStudyTimeSec || 0) + totalTimeSec,
+        },
+        tx,
+      );
+      return { ...levelInfo, newStreak };
+    });
+
+    // 5. 응답 매핑
+    return this.mapToFinishResponse(session, answers, result, detail);
+  }
+
+  /**
+   * 세션 및 답변 데이터를 조회하고, 종료 가능 여부를 검증하는 메서드
+   */
+  private async validateAndLoadSession(sessionId: number) {
+    const session = await this.sessionsRepository.findById(sessionId);
+    if (!session) throw new NotFoundException('세션을 찾을 수 없습니다.');
+    if (session.status === 'COMPLETED') throw new BadRequestException('이미 종료된 세션입니다.');
+
+    const answers = await this.prisma.userAnswer.findMany({
+      where: { sessionId },
+      include: { question: true, extraQuestion: true },
+    });
+
+    if (answers.some((ans) => ans.overallScore === null)) {
+      throw new BadRequestException({
+        code: 'ASSESSMENT_PENDING',
+        message: '아직 AI 채점이 진행 중인 답변이 있습니다.',
+      });
+    }
+
+    return { session, answers };
+  }
+
+  /**
+   * 누적 경험치를 기반으로 레벨업을 처리하고, UI 표시용 게이지 정보를 계산하는 메서드
+   */
+  private async processLevelUp(currentLevel: number, totalXp: number) {
+    let newLevel = currentLevel;
+
+    // 현재 레벨의 졸업 요건 조회
+    let currentLevelReqXp = await this.xpRepository.findRequiredXpByLevel(newLevel);
+
+    // 레벨업 루프
+    while (totalXp >= currentLevelReqXp) {
+      if (newLevel >= 100) break;
+      newLevel++;
+      currentLevelReqXp = await this.xpRepository.findRequiredXpByLevel(newLevel);
+    }
+
+    // UI 범위 계산
+    // prevReqXp: 이전 레벨까지 필요했던 총 경험치 (이번 레벨의 바닥)
+    // reqXp: 다음 레벨까지 필요한 총 경험치 (이번 레벨의 천장)
+
+    // Level 1이면 바닥은 0, Level 2이상이면 (Level-1)의 요구량
+    const prevReqXp =
+      newLevel > 1 ? await this.xpRepository.findRequiredXpByLevel(newLevel - 1) : 0;
+
+    const reqXp = await this.xpRepository.findRequiredXpByLevel(newLevel);
+
+    // 현재 레벨에서의 진행도 (Relative XP) 계산
+    const currentLevelXp = totalXp - prevReqXp;
+
+    return {
+      level: newLevel,
+      currentXp: currentLevelXp, // UI에는 초기화된 값 전달
+      prevRequiredXpForNextLevel: prevReqXp,
+      requiredXpForNextLevel: reqXp,
+    };
+  }
+
+  /**
+   * 처리된 결과를 클라이언트 응답 DTO 형식으로 매핑하는 메서드
+   */
+  private mapToFinishResponse(
+    session: any,
+    answers: any[],
+    result: TransactionResult,
+    gainedXp: GainedXpDetailDto,
+  ): FinishSessionResponseDto {
+    return {
+      currentXp: result.currentXp,
+      prevRequiredXpForNextLevel: result.prevRequiredXpForNextLevel,
+      requiredXpForNextLevel: result.requiredXpForNextLevel,
+      level: result.level,
+      gainedXp,
+      category: session.category as unknown as Domain,
+      difficulty: session.difficulty as unknown as Difficulty,
+      questions: answers.map((ans) => {
+        const isTail = !!ans.extraQuestionId;
+        return {
+          content: isTail
+            ? (ans.extraQuestion?.content ?? '내용 없음')
+            : (ans.question?.content ?? '내용 없음'),
+          type: isTail ? 'TAIL' : 'NORMAL',
+          score: ans.overallScore || 0,
+        };
+      }),
     };
   }
 }

--- a/apps/be/src/learning/sessions/sessions.module.ts
+++ b/apps/be/src/learning/sessions/sessions.module.ts
@@ -2,11 +2,14 @@ import { Module } from '@nestjs/common';
 
 import { QuestionProviderModule } from '@/modules/question-provider/question-provider.module';
 import { NormalizeModule } from '@/normalize/normalize.module';
+import { StreakCalculatorService } from '@/users/stats/services/streak-calculator.service';
+import { XpCalculatorService } from '@/users/stats/services/xp-calculator.service';
 import { UsersModule } from '@/users/users.module';
 
 import { DatabaseModule } from '../../infra/database/database.module';
 import { ClovaSttProvider } from '../../stt/providers/clova-stt.provider';
 import { SttModule } from '../../stt/stt.module';
+import { XpRepository } from '../xp/repository/xp.repository';
 import { SessionsRecordController } from './controllers/sessions-record.controller';
 import { SessionsController } from './controllers/sessions.controller';
 import { ObjectStorageProvider } from './providers/object-storage.provider';
@@ -29,6 +32,9 @@ import { SessionsService } from './services/sessions.service';
     GuideBuilderService,
     DeepDiveService,
     AnswerRepository,
+    XpRepository,
+    StreakCalculatorService,
+    XpCalculatorService,
   ],
   exports: [DeepDiveService],
 })

--- a/apps/be/src/learning/xp/repository/xp.repository.ts
+++ b/apps/be/src/learning/xp/repository/xp.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '@/infra/database/prisma.service';
+
+@Injectable()
+export class XpRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // 특정 레벨의 필요 경험치를 조회하는 메서드
+  async findRequiredXpByLevel(level: number): Promise<number> {
+    const xpData = await this.prisma.xp.findUnique({
+      where: { level },
+    });
+
+    // DB에 데이터가 없으면 fallback 로직 (시딩이 안됐을 경우 대비)
+    return xpData ? xpData.requiredXp : level * 1000;
+  }
+}

--- a/apps/be/src/users/stats/repository/user-stats.repository.ts
+++ b/apps/be/src/users/stats/repository/user-stats.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '@/infra/database/prisma.service';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class UserStatsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 특정 유저의 학습 통계를 조회하는 메서드
+   * @param userId 유저 ID
+   * @param tx (Optional) 외부 트랜잭션 클라이언트
+   */
+  async findStatsByUserId(userId: number, tx?: Prisma.TransactionClient) {
+    const client = tx ?? this.prisma;
+    return client.userStats.findUnique({
+      where: { userId },
+    });
+  }
+
+  /**
+   * 유저의 학습 통계 정보를 갱신하거나 새로 생성하는 메서드 (Upsert)
+   * @param userId 유저 ID
+   * @param data 업데이트할 데이터 (레벨, 경험치, 총 문제 수)
+   * @param tx (Optional) 외부 트랜잭션 클라이언트
+   */
+  async upsertStats(
+    userId: number,
+    data: {
+      level: number;
+      currentXp: number;
+      totalSolvedQuestions: number;
+      streakDays?: number;
+      totalStudyTimeSec?: number;
+    },
+    tx?: Prisma.TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+
+    return client.userStats.upsert({
+      where: { userId },
+      update: {
+        level: data.level,
+        currentXp: data.currentXp,
+        totalSolvedQuestions: data.totalSolvedQuestions,
+        ...(data.streakDays !== undefined && { streakDays: data.streakDays }),
+        ...(data.totalStudyTimeSec !== undefined && { totalStudyTimeSec: data.totalStudyTimeSec }),
+        updatedAt: new Date(),
+      },
+      create: {
+        userId,
+        level: data.level,
+        currentXp: data.currentXp,
+        totalSolvedQuestions: data.totalSolvedQuestions,
+        streakDays: data.streakDays ?? 1,
+        totalStudyTimeSec: data.totalStudyTimeSec ?? 0,
+      },
+    });
+  }
+}

--- a/apps/be/src/users/stats/services/streak-calculator.service.ts
+++ b/apps/be/src/users/stats/services/streak-calculator.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+
+import { DateUtil } from '@/common/utils/date.util';
+
+// 학습 연속일(Streak) 계산을 담당하는 서비스
+@Injectable()
+export class StreakCalculatorService {
+  // 마지막 학습일과 현재 상태를 기반으로 최신 스트릭을 반환하는 메서드
+  calculate(lastUpdatedAt: Date | null | undefined, currentStreak: number): number {
+    // 1. 첫 학습
+    if (!lastUpdatedAt) return 1;
+
+    const todayStr = DateUtil.getKstDateString();
+    const lastDateStr = DateUtil.getKstDateString(lastUpdatedAt);
+
+    // 2. 오늘 이미 학습함 (0일차 보정 포함)
+    if (todayStr === lastDateStr) {
+      return currentStreak === 0 ? 1 : currentStreak;
+    }
+
+    // 3. 어제 학습함 (연속 성공)
+    const yesterdayStr = DateUtil.getYesterdayKstDateString();
+    if (lastDateStr === yesterdayStr) {
+      return currentStreak + 1;
+    }
+
+    // 4. 끊김 (초기화)
+    return 1;
+  }
+}

--- a/apps/be/src/users/stats/services/xp-calculator.service.ts
+++ b/apps/be/src/users/stats/services/xp-calculator.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+
+import { Difficulty } from '@/common/enums/learning.enum';
+
+// XP 계산에 필요한 가중치 및 설정값 상수
+const XP_CONFIG = {
+  BASE_SESSION_XP: 100,
+  BONUS: {
+    DIFFICULTY: { HARD: 0.5, MEDIUM: 0.2, EASY: 0 },
+    DEEP_DIVE_PER_Q: 20,
+  },
+};
+
+// 학습 결과에 따른 XP 획득량 계산을 담당하는 서비스
+@Injectable()
+export class XpCalculatorService {
+  // 난이도와 답변(꼬리 질문 여부)을 기반으로 최종 획득 XP를 계산하는 메서드
+  calculate(difficulty: Difficulty, answers: { extraQuestionId: string | null }[]) {
+    // 1. 기본 XP
+    const baseXp = XP_CONFIG.BASE_SESSION_XP;
+
+    // 2. 난이도 보너스
+    let multiplier = XP_CONFIG.BONUS.DIFFICULTY.EASY;
+    if (difficulty === Difficulty.HARD) multiplier = XP_CONFIG.BONUS.DIFFICULTY.HARD;
+    else if (difficulty === Difficulty.MEDIUM) multiplier = XP_CONFIG.BONUS.DIFFICULTY.MEDIUM;
+
+    const difficultyBonus = Math.floor(baseXp * multiplier);
+
+    // 3. 딥다이브 보너스
+    const tailCount = answers.filter((a) => !!a.extraQuestionId).length;
+    const deepDiveBonus = tailCount * XP_CONFIG.BONUS.DEEP_DIVE_PER_Q;
+
+    return {
+      totalGainedXp: baseXp + difficultyBonus + deepDiveBonus,
+      detail: {
+        baseXp,
+        difficultyBonus: difficultyBonus > 0 ? difficultyBonus : null,
+        deepDiveBonus: deepDiveBonus > 0 ? deepDiveBonus : null,
+      },
+    };
+  }
+}

--- a/apps/be/src/users/users.module.ts
+++ b/apps/be/src/users/users.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 
 import { UserCreditsRepository } from './credits/user-credits.repository';
+import { UserStatsRepository } from './stats/repository/user-stats.repository';
 
 @Module({
-  providers: [UserCreditsRepository],
-  exports: [UserCreditsRepository],
+  providers: [UserCreditsRepository, UserStatsRepository],
+  exports: [UserCreditsRepository, UserStatsRepository],
 })
 export class UsersModule {}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #55 

<br/>

## 🔍 작업 내용

사용자가 학습을 마쳤을 때 호출되는 세션 종료 API(POST /api/learning/sessions/{sessionId}/finish)를 구현했습니다.

백엔드에서 **학습 세션 종료 및 리워드(XP, 레벨, 스트릭) 정산 API**를 구현한 내용에 대한 PR 본문입니다. 이슈 #55의 요구사항과 실제 구현된 코드 로직을 중심으로 작성했습니다.

### 1. 세션 종료 및 보상 정산 로직

* **고정 XP 시스템**: 점수 비례 방식 대신 세션 완료 시 고정 경험치(100XP)를 부여하며, 난이도별 가중치(Hard 50%, Medium 20%) 및 꼬리 질문(딥다이브) 개수당 추가 보너스를 합계하여 최종 XP를 산출합니다.
* **레벨업 및 XP 롤오버(Roll-over)**: 획득한 경험치로 인해 레벨업 기준을 초과할 경우, 초과분만큼 다음 레벨의 경험치로 이월되도록 구현했습니다. (예: 1레벨 900XP에서 200XP 획득 시 -> 2레벨 100XP)
* **통계 데이터 집계**: 답변에 기록된 `timeSpentSec`를 전수 합산하여 세션의 총 학습 시간 및 유저의 누적 학습 시간을 갱신합니다.

### 2. 스트릭(Streak) 및 날짜 처리

* **연속 학습일 계산**: 한국 표준시(KST)를 기준으로 마지막 학습일(`updatedAt`)과 오늘 날짜를 비교합니다.
* **날짜 비교 로직**: 어제 공부하고 오늘 다시 완료한 경우 스트릭을 +1 하며, 하루 이상 공백이 생길 경우 1로 초기화합니다. 오늘 이미 학습한 기록이 있는 경우 기존 스트릭을 유지합니다.

### 3. 예외 처리 및 데이터 무결성

* **미채점 답변 검증**: 세션 내 답변 중 AI 채점이 완료되지 않은(`overallScore === null`) 항목이 하나라도 있다면 종료를 방지하고 `ASSESSMENT_PENDING` 에러를 반환합니다.
* **상태 기반 트랜잭션**: `Prisma.$transaction`을 통해 세션 상태 업데이트와 유저 스탯 갱신을 원자적으로 처리하며, `ACTIVE` 상태인 세션에 대해서만 종료 로직이 수행되도록 방어 조건을 설정했습니다.

### 4. API 명세 및 데이터 매핑

* **Zod 기반 DTO**: `FinishSessionResponseSchema`를 통해 응답 데이터 형식을 정의하고 Swagger 문서화를 자동화했습니다.
* **UI 최적화 데이터**: 프론트엔드 게이지 바 렌더링을 위해 현재 레벨에서의 상대적 경험치(`currentXp`)와 해당 레벨의 시작/종료 임계값(`prevRequiredXp`, `requiredXp`)을 함께 반환합니다.


<br/>

## 📷 스크린샷

ui 변경사항이 있다면 추가 + 테스트 커버리지도 좋음!

<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `15분`
> 리뷰어에게 남기고 싶은 말) 

<br/>

## 📄 추가 전달 사항
문제 해결과정은 wiki에 작성!! 토의를 하고 싶다면 discussion으로!

- 공유한 내용이나 반영된 내용은 wiki에 이어서 작성(사고나 작업의 변화를 보기 위해 기존의 내용 수정X)
