### PR TITLE
fix: LLM cleanup 호출 조건 오류 수정 및 빈 텍스트 응답 처리 개선 #100

### DIFF
--- a/apps/be/src/learning/sessions/services/sessions-record.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions-record.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import { NormalizeService } from '@/normalize/normalize.service';
 
@@ -10,6 +10,8 @@ import type { RecordSessionAnswerDto } from '../schemas/record-session-answer.sc
 
 @Injectable()
 export class SessionsRecordService {
+  private readonly logger = new Logger(SessionsRecordService.name);
+
   constructor(
     private readonly sessionsRepository: SessionsRepository,
     private readonly storageProvider: ObjectStorageProvider,
@@ -27,91 +29,70 @@ export class SessionsRecordService {
     let objectKey: string | null = null;
 
     try {
-      console.log('[SessionsRecordService] 1. Starting record process');
-
       /**
        * 세션 존재 확인
        */
-      console.log('[SessionsRecordService] 2. Checking session existence:', sessionId);
       const session = await this.sessionsRepository.findById(sessionId);
 
       if (!session) {
-        console.error('[SessionsRecordService] Session not found:', sessionId);
+        this.logger.error('Session not found', { sessionId });
+
         throw new NotFoundException({
           code: 'SESSION_NOT_FOUND',
           message: '세션을 찾을 수 없습니다.',
         });
       }
-      console.log('[SessionsRecordService] Session found:', session);
 
       /**
        * 오디오 포맷 정규화
        * - speech 모듈에서 검증된 로직
        * - wav / mono / 16kHz 등 STT 요구사항 충족
        */
-      console.log('[SessionsRecordService] 3. Normalizing audio');
       const { buffer, contentType, filename } = await normalizeAudio(file);
-      console.log('[SessionsRecordService] Audio normalized:', {
-        contentType,
-        filename,
-        bufferSize: buffer.length,
-      });
 
       /**
        * Object Storage 업로드
        * - STT 서버가 직접 접근 가능한 위치
        */
-      console.log('[SessionsRecordService] 4. Uploading to Object Storage');
       objectKey = await this.storageProvider.upload(buffer, contentType, filename);
-      console.log('[SessionsRecordService] Uploaded to storage:', objectKey);
 
       /**
        * STT 요청
        * - 파일을 다시 보내지 않음
        * - objectKey 기준으로 STT 서버가 fetch
        */
-      console.log('[SessionsRecordService] 5. Requesting STT');
       const sttResult = await this.sttService.transcribe({
         objectKey,
         language: 'ko-KR',
         questionId: dto.questionId,
         extraQuestionId: dto.extraQuestionId,
       });
-      console.log('[SessionsRecordService] STT result:', sttResult);
 
       /**
        * stt -> 정규화 로직
        */
-      console.log('[NormalizeService] Normalizing STT text for draft');
       const normalizeResult = await this.normalizeService.normalizeForDraft(sttResult.text);
-      console.log(
-        `[NormalizeService] Normalize completed | rawLength=${normalizeResult.rawText.length}, preLength=${normalizeResult.preNormalizedText.length}, draftLength=${normalizeResult.draftText.length}`,
-      );
-
       /**
        * 응답 반환 -> 일단 최종 변환만 작성
        * 필요시 응답 변환
        * preNormalizedText: 음차만 변경
        * rawText: 기존 stt 텍스트
        */
-      console.log('[SessionsRecordService] 7. Record process completed successfully');
       return {
         sttText: normalizeResult.draftText,
       };
     } catch (error) {
-      console.error('[SessionsRecordService] ERROR in record process:', error);
+      this.logger.error('ERROR in record process', error);
       throw error;
     } finally {
       if (objectKey) {
         try {
-          console.log('[SessionsRecordService] 6. Deleting temp object:', objectKey);
           await this.storageProvider.deleteObject(objectKey);
         } catch (cleanupError) {
-          console.error(
-            '[SessionsRecordService] Failed to delete temp object:',
+          this.logger.error('Failed to delete temp object', {
             objectKey,
-            cleanupError,
-          );
+            error: cleanupError,
+          });
         }
       }
     }

--- a/apps/be/src/normalize/llm-cleanup.service.ts
+++ b/apps/be/src/normalize/llm-cleanup.service.ts
@@ -11,8 +11,6 @@ export class LlmCleanupService {
   private readonly baseUrl = process.env.CLOVA_BASE_URL!;
 
   async cleanup(text: string): Promise<string> {
-    console.log('LLM호출');
-
     try {
       const response = await axios.post(
         `${this.baseUrl}/v1/chat-completions/${this.model}`,

--- a/apps/be/src/normalize/normalize.service.ts
+++ b/apps/be/src/normalize/normalize.service.ts
@@ -26,7 +26,7 @@ export class NormalizeService {
     //  LLM Cleanup (User-friendly, optional)
     let draftText = preNormalizedText;
 
-    if (!shouldCallLlm(preNormalizedText)) {
+    if (shouldCallLlm(preNormalizedText)) {
       try {
         this.logger.debug(`Calling LLM cleanup (length=${preNormalizedText.length})`);
         draftText = await this.llmCleanupService.cleanup(preNormalizedText);
@@ -35,6 +35,14 @@ export class NormalizeService {
         this.logger.warn('LLM cleanup failed, falling back to preNormalizedText', error);
         draftText = preNormalizedText;
       }
+    }
+
+    if (!originalText.trim()) {
+      return {
+        rawText: originalText,
+        preNormalizedText: '입력받은 음성이 없습니다.',
+        draftText: '입력받은 음성이 없습니다.',
+      };
     }
 
     return {

--- a/apps/be/src/normalize/utils/should-call-llm.ts
+++ b/apps/be/src/normalize/utils/should-call-llm.ts
@@ -1,12 +1,10 @@
 // LLM 호출 여부 판단 유틸
+// TODO : 상황에 따라 조금 더 정규화 필요
 export function shouldCallLlm(text: string): boolean {
   if (!text) return false;
 
   // 너무 짧은 텍스트의 경우 LLM 호출 하더라도 변화 거의 없음
   if (text.length < 50) return false;
 
-  // 아주 단순한 반복 감지
-  const hasRepeatedWord = /(\\b\\w+\\b)(\\s+\\1)+/i.test(text);
-
-  return hasRepeatedWord;
+  return true;
 }

--- a/apps/be/src/stt/providers/clova-stt.provider.ts
+++ b/apps/be/src/stt/providers/clova-stt.provider.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import axios from 'axios';
 
 @Injectable()
 export class ClovaSttProvider {
+  private readonly logger = new Logger(ClovaSttProvider.name);
+
   constructor(private config: ConfigService) {}
 
   // 안전한 URL 조합기: base의 꼬리 슬래시/중복 슬래시를 정규화
@@ -15,12 +17,11 @@ export class ClovaSttProvider {
   }
 
   async requestSTT(objectKey: string, language: string, boostWords: string[]): Promise<string> {
-    console.log('[STT BOOST WORDS]', boostWords);
-
     const url = this.joinUrl(
       this.config.get<string>('CLOVA_SPEECH_INVOKE_URL') ?? '',
       'recognizer/object-storage',
     );
+
     const boostings =
       boostWords && boostWords.length > 0
         ? [
@@ -30,6 +31,12 @@ export class ClovaSttProvider {
             },
           ]
         : undefined;
+
+    this.logger.log('Requesting Clova STT', {
+      objectKey,
+      language,
+      boostWordsCount: boostWords?.length ?? 0,
+    });
 
     const response = await axios.post(
       url,
@@ -50,46 +57,37 @@ export class ClovaSttProvider {
       },
     );
 
-    // 테스트 확인용 상세로그 입니다!!!!!!! -> 나중에 지우면 될 것 같아요!
-    console.log('-----------------------------');
-    console.log(' Clova RAW response:', JSON.stringify(response.data, null, 2));
-    console.log('--- API /api/stt 상세 로그 ---');
-    console.log('1. 전체 텍스트 (화자 구분 포함):', response.data.text);
-
-    console.log('\n2. 화자별 세그먼트 목록 (시간 정보 포함):');
     if (response.data.segments && response.data.segments.length > 0) {
       response.data.segments.forEach((segment) => {
-        // segment.speaker가 undefined일 경우, diarization.label 또는 speaker.label 사용 시도
         const speakerLabel = segment.diarization
           ? segment.diarization.label
           : segment.speaker
             ? segment.speaker.label
             : 'N/A';
-        // 정확도
+
         const confidence = segment.confidence;
-        // 인식된 단어 목록
         const words = segment.words;
-        console.log(
-          `[화자 ${speakerLabel}] 시작: ${segment.start}ms, 종료: ${segment.end}ms, 내용: ${segment.text}`,
-        );
-        console.log(`    - 정확도: ${confidence !== undefined ? confidence.toFixed(2) : 'N/A'}`);
-        console.log(`    - 인식된 단어들: ${words ? words.map((w) => w[2]).join(', ') : 'N/A'}`);
+
+        // 값 접근만 유지 (로직 변경 없음)
+        void speakerLabel;
+        void confidence;
+        void words;
+        void segment.start;
+        void segment.end;
+        void segment.text;
       });
-    } else {
-      console.log('세그먼트(segments) 정보가 없거나 비어 있습니다. 화자 인식이 실패했을 가능성.');
     }
 
-    console.log('\n3. 응답바디 키워드 부스팅 정보:');
-    const boostings_response = response.data?.params?.boostings;
-    if (boostings_response && boostings_response.length > 0) {
-      boostings_response.forEach((b, idx) => {
-        console.log(`  #${idx + 1}: ${b.words}`);
+    const boostingsResponse = response.data?.params?.boostings;
+    if (boostingsResponse && boostingsResponse.length > 0) {
+      boostingsResponse.forEach((b) => {
+        void b.words;
       });
-    } else {
-      console.log('  부스팅 없음');
     }
 
-    console.log('-----------------------------');
+    this.logger.log('Clova STT completed', {
+      textLength: response.data.text?.length,
+    });
 
     return response.data.text;
   }

--- a/apps/be/src/stt/services/stt.service.ts
+++ b/apps/be/src/stt/services/stt.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 
 import { SttBoostingBuilder } from '../builders/stt-boosting.builder';
 import { ClovaSttProvider } from '../providers/clova-stt.provider';
@@ -6,6 +6,8 @@ import { SttQuestionLoaderService } from './stt-question-loader.service';
 
 @Injectable()
 export class SttService {
+  private readonly logger = new Logger(SttService.name);
+
   constructor(
     private readonly clovaSttProvider: ClovaSttProvider,
     private readonly questionLoader: SttQuestionLoaderService,
@@ -19,7 +21,7 @@ export class SttService {
   }): Promise<{ text: string }> {
     try {
       // 1. 메서드 진입
-      console.log('[STT] transcribe start', {
+      this.logger.log('transcribe start', {
         objectKey: params.objectKey,
         language: params.language,
         questionId: params.questionId,
@@ -34,28 +36,28 @@ export class SttService {
         throw new Error('INVALID_QUESTION_TARGET');
       }
 
-      // 2. QuestionMeta 로딩 시작
-      console.log('[STT] loading question meta...');
+      // 2. QuestionMeta 로딩
+      this.logger.log('loading question meta...');
       const questionMeta = await this.questionLoader.loadQuestionMeta({
         questionId: params.questionId,
         extraQuestionId: params.extraQuestionId,
       });
 
-      // 4. boostWords 생성
+      // 3. boostWords 생성
       const boostWords = SttBoostingBuilder.build(questionMeta);
-      console.log('[STT] boostWords built', {
+      this.logger.log('boostWords built', {
         boostWordsCount: boostWords.length,
       });
 
-      // 3. QuestionMeta 로딩 완료
-      console.log('[STT] question meta loaded', {
+      // 4. QuestionMeta 로딩 완료
+      this.logger.log('question meta loaded', {
         questionId: questionMeta.questionId,
         topicId: questionMeta.topicId,
         mustIncludeLength: questionMeta.mustInclude?.length,
       });
 
-      // 5. Clova STT 호출 직전
-      console.log('[STT] calling Clova STT', {
+      // 5. Clova STT 호출
+      this.logger.log('calling Clova STT', {
         objectKey: params.objectKey,
         language: params.language,
       });
@@ -66,21 +68,22 @@ export class SttService {
         boostWords,
       );
 
-      // 6. Clova STT 응답 수신
-      console.log('[STT] Clova STT success', {
+      // 6. STT 성공
+      this.logger.log('Clova STT success', {
         textLength: text?.length,
         textPreview: text?.slice(0, 50),
       });
 
       return { text };
     } catch (error) {
-      // 7. 에러 발생 지점 로그
-      console.error('[STT ERROR] occurred');
-      console.error('[STT ERROR] raw error:', error);
+      // 7. 에러 처리
+      this.logger.error('STT error occurred', error);
 
       if ((error as any)?.response) {
-        console.error('[STT ERROR] Clova response status:', (error as any).response.status);
-        console.error('[STT ERROR] Clova response data:', (error as any).response.data);
+        this.logger.error('Clova response error', {
+          status: (error as any).response.status,
+          data: (error as any).response.data,
+        });
       }
 
       throw new InternalServerErrorException({


### PR DESCRIPTION
## 🔗 관련 이슈

- close #100

<br/>

## 🔍 작업 내용

무응답 시 llm을 호출해서 임의로 아무말을 하게 되는 버그가 있어서 수정했습니다.

- NormalizeService에서 LLM cleanup 호출 조건이 반대로 적용되던 로직 수정
- 빈 문자열(STT 무응답) 입력 시 LLM을 호출하지 않도록 처리
- LLM cleanup 실패 시 preNormalize 결과로 fallback 되도록 안정성 보완
- 기존 `console.log`를 `logger`로 변경
<br/>

## 📷 스크린샷

- UI 변경 없음

### 무응답시 (기존)
<img width="571" height="299" alt="image" src="https://github.com/user-attachments/assets/2e0a60a3-43dd-4df7-90d1-28bdc31cd99a" />

### 무응답시 (수정)
<img width="1059" height="677" alt="image" src="https://github.com/user-attachments/assets/1fb39f66-5494-428a-bbe4-0ed36f243de2" />


<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

> 리뷰 예상 시간: `2분` 
<br/>
