### PR TITLE
Fix/#108 학습 종료시 모달이 뜨지 않는 이슈 해결

### DIFF
--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 
 import {
   finishSessionApi,
@@ -22,16 +22,16 @@ const FloatingStepBar = () => {
 
   const [rewardData, setRewardData] = useState<FinishSessionResponseDTO | null>(null);
   const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
-  const [clickedButtons, setClickedButtons] = useState<Set<string>>(new Set());
+  const clickedButtonsRef = useRef<Set<string>>(new Set());
 
   const isFeedbackPhase =
     phase === ANSWER_PHASE.FEEDBACK_LOADING || phase === ANSWER_PHASE.FEEDBACK_DONE;
 
   const markClicked = (buttonName: string) => {
-    setClickedButtons((prev) => new Set(prev).add(buttonName));
+    clickedButtonsRef.current.add(buttonName);
   };
 
-  const isClicked = (buttonName: string) => clickedButtons.has(buttonName);
+  const isClicked = (buttonName: string) => clickedButtonsRef.current.has(buttonName);
 
   const handleEndLearning = async () => {
     if (!sessionId || isClicked('endLearning')) return;
@@ -39,7 +39,6 @@ const FloatingStepBar = () => {
 
     const data = await finishSessionApi({ sessionId });
     setRewardData(data);
-    useLearningSession.getState().resetQuestion();
     setIsRewardModalOpen(true);
   };
 
@@ -90,7 +89,11 @@ const FloatingStepBar = () => {
       </ActionBar.Button>
       {isFeedbackPhase ? (
         <>
-          <ActionBar.Button onClick={handleDeepDive} className="flex items-center gap-2">
+          <ActionBar.Button
+            onClick={handleDeepDive}
+            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE}
+            className="flex items-center gap-2"
+          >
             <Binoculars className="hidden h-4 w-4 sm:block" />
             딥다이브
           </ActionBar.Button>
@@ -134,7 +137,7 @@ const ActionBarButton = ({ children, className, withDivider, ...rest }: ActionBa
   return (
     <button
       className={cn(
-        'px-3 py-2 text-xs sm:px-6 sm:text-sm',
+        'px-3 py-2 text-xs disabled:cursor-not-allowed sm:px-6 sm:text-sm',
         withDivider &&
           'relative after:absolute after:top-1/2 after:-right-1 after:h-1/2 after:w-px after:-translate-y-1/2 after:bg-gray-300',
         className,
@@ -150,7 +153,7 @@ const ActionBarPrimaryButton = ({ children, className, ...rest }: ActionBarButto
   return (
     <ActionBarButton
       className={cn(
-        'rounded-2xl bg-primary disabled:cursor-not-allowed disabled:bg-gray-600 disabled:text-gray-200',
+        'rounded-2xl bg-primary disabled:bg-gray-600 disabled:text-gray-200',
         className,
       )}
       {...rest}

--- a/apps/fe/src/features/learning/components/question/reward-modal.tsx
+++ b/apps/fe/src/features/learning/components/question/reward-modal.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useMemo } from 'react';
 
+import useLearningSession from '@/lib/stores/learning-session';
 import * as Dialog from '@radix-ui/react-dialog';
 import type { FinishSessionResponseDTO } from '@repo/shared/types/learning';
 import { useNavigate } from '@tanstack/react-router';
@@ -108,6 +109,7 @@ const RewardModal = forwardRef<HTMLDivElement, RewardModalProps>(
     const navigate = useNavigate();
 
     const handleClose = () => {
+      useLearningSession.getState().resetQuestion();
       navigate({ to: '/learning', replace: true });
     };
 

--- a/apps/fe/src/routes/learning/question.tsx
+++ b/apps/fe/src/routes/learning/question.tsx
@@ -74,7 +74,7 @@ const QuestionPageContent = () => {
   return (
     <div className="relative mx-auto flex min-h-screen max-w-250 flex-col gap-8 p-6 sm:p-10">
       <QuestionHeader />
-      <QuestionContent />
+      <QuestionContent key={`question-content-${question?.questionId}`} />
       <VoiceRecorderSection
         key={`voice-recorder-section-${question?.questionId}`}
         onRecordingComplete={handleRecordingComplete}

--- a/apps/fe/src/routes/learning/question.tsx
+++ b/apps/fe/src/routes/learning/question.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 
 import { getFeedbackApi, submitRecordApi } from '@/apis/learning-api';
 import AnswerSection from '@/features/learning/components/question/answer-section';
@@ -20,12 +20,6 @@ const QuestionPageContent = () => {
   const sessionId = useLearningSession((state) => state.sessionId);
   const question = useLearningSession((state) => state.question);
   const setRemainedCredit = useLearningSession((state) => state.setRemainedCredit);
-
-  const lastQuestionRef = useRef(question);
-  if (question) {
-    lastQuestionRef.current = question;
-  }
-  const activeQuestion = question || lastQuestionRef.current;
 
   const { setPhase, setSttText, setFeedback, setAssessmentStatus, answerId } = useAnswerFlow();
 
@@ -72,7 +66,7 @@ const QuestionPageContent = () => {
     }
   };
 
-  if (!activeQuestion) {
+  if (!question) {
     navigate({ to: '/learning', replace: true });
     return null;
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #108

<br/>

## 🔍 작업 내용

- 학습 종료 시 리워드 모달이 표시되지 않는 문제 수정
    - `resetQuestion()` 호출 시점을 모달이 닫힐 때로 이동하여 컴포넌트 언마운트 전에 모달이 열리도록 수정
- 버튼 클릭 상태 관리를 `useState`에서 `useRef`로 변환하여 불필요한 리렌더링 방지
- 딥다이브 버튼에 비활성화 상태 추가 (피드백 완료 전까지 클릭 불가)
- `question.tsx`에서 불필요한 `lastQuestionRef` 로직 제거
- `question.tsx`에서 `QuestionContent`에 key 추가 -> 다음/꼬리 질문 이동시 가이드가 닫힌 형태로 초기화도되록 수정

<br/>

## 📷 스크린샷

ui 변경사항이 있다면 추가 + 테스트 커버리지도 좋음!

<br/>

## ✅ 체크리스트

- [ ]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [ ]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [ ]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

> 리뷰 예상 시간: 5분
리뷰어에게 남기고 싶은 말) 학습 종료 버튼 클릭 시 모달이 안 뜨던 문제의 원인은 resetQuestion() 호출로 인해 컴포넌트가 언마운트되어 setIsRewardModalOpen(true)가 실행되어도 모달이 표시되지 않았던 것이었습니다.
> 

<br/>

## 📄 추가 전달 사항

