### PR TITLE
Feat/#132 피드백 ui에 대한 예외 처리

### DIFF
--- a/apps/fe/src/features/learning/components/question/feedback-section.tsx
+++ b/apps/fe/src/features/learning/components/question/feedback-section.tsx
@@ -29,16 +29,9 @@ const getStatusMessage = (assessmentStatus: AssessmentStatus | null) => {
 };
 
 const FeedbackSection = () => {
-  const { feedback, phase, assessmentStatus } = useAnswerFlow();
+  const { feedback, phase, assessmentStatus, isInsufficientAnswer } = useAnswerFlow();
 
   const isFeedbackLoading = phase === ANSWER_PHASE.FEEDBACK_LOADING;
-
-  const isInsufficientAnswer =
-    feedback &&
-    ((feedback.strengths.length === 0 &&
-      feedback.weaknesses.length === 0 &&
-      feedback.suggestions.length === 0) ||
-      feedback.overallScore === 0);
 
   if (phase !== ANSWER_PHASE.FEEDBACK_LOADING && phase !== ANSWER_PHASE.FEEDBACK_DONE) return null;
 

--- a/apps/fe/src/features/learning/components/question/feedback-section.tsx
+++ b/apps/fe/src/features/learning/components/question/feedback-section.tsx
@@ -1,7 +1,8 @@
 import { ANSWER_PHASE, useAnswerFlow } from '@/features/learning/lib/contexts/answer-flow-context';
-import { ASSESSMENT_STATUS } from '@repo/shared/constants/learning';
+import { ASSESSMENT_STATUS, type AssessmentStatus } from '@repo/shared/constants/learning';
+import type { GetFeedbackResponseDTO } from '@repo/shared/types/learning';
 
-import { Bot, CircleCheck, Lightbulb, Loader2, TriangleAlert } from 'lucide-react';
+import { BookOpen, Bot, CircleCheck, Lightbulb, Loader2, TriangleAlert } from 'lucide-react';
 
 const ASSESSMENT_STATUS_MESSAGE: Record<string, string> = {
   [ASSESSMENT_STATUS.QUEUED]: '평가 대기 중...',
@@ -11,26 +12,24 @@ const ASSESSMENT_STATUS_MESSAGE: Record<string, string> = {
   [ASSESSMENT_STATUS.FAILED]: '평가에 실패했습니다.',
 };
 
+const getStatusMessage = (assessmentStatus: AssessmentStatus | null) => {
+  if (!assessmentStatus) return '평가를 시작하고 있습니다...';
+  return ASSESSMENT_STATUS_MESSAGE[assessmentStatus] || '처리 중...';
+};
+
 const FeedbackSection = () => {
   const { feedback, phase, assessmentStatus } = useAnswerFlow();
 
   const isFeedbackLoading = phase === ANSWER_PHASE.FEEDBACK_LOADING;
 
-  const getStatusMessage = () => {
-    if (!assessmentStatus) return '평가를 시작하고 있습니다...';
-    return ASSESSMENT_STATUS_MESSAGE[assessmentStatus] || '처리 중...';
-  };
+  const isInsufficientAnswer =
+    feedback &&
+    ((feedback.strengths.length === 0 &&
+      feedback.weaknesses.length === 0 &&
+      feedback.suggestions.length === 0) ||
+      feedback.overallScore === 0);
 
-  if (isFeedbackLoading) {
-    return (
-      <div className="mt-6 flex flex-col items-center gap-3 rounded-lg bg-primary/5 p-4">
-        <Loader2 className="h-6 w-6 animate-spin text-primary" />
-        <p className="text-sm font-medium text-primary">{getStatusMessage()}</p>
-      </div>
-    );
-  }
-
-  if (!feedback) return null;
+  if (phase !== ANSWER_PHASE.FEEDBACK_LOADING && phase !== ANSWER_PHASE.FEEDBACK_DONE) return null;
 
   return (
     <section className="space-y-4">
@@ -38,49 +37,83 @@ const FeedbackSection = () => {
         <Bot className="h-10 w-10 rounded-lg bg-linear-to-br from-violet-500 to-indigo-600 p-2 text-white shadow-md" />
         AI 피드백
       </h3>
-      <div className="grid grid-cols-2 gap-6">
-        <div className="space-y-4 rounded-2xl border border-[#22C55E] bg-[#F0FDF4]/50 p-6">
-          <p className="flex items-center gap-2 text-lg font-bold text-[#14532D]">
-            <CircleCheck className="h-5 w-5 text-[#16A34A]" />
-            정확한 개념 설명
-          </p>
-          <ul className="flex list-disc flex-col gap-2 pl-5 text-dark-green marker:text-[#22C55E]">
-            {feedback.strengths.map((strength, index) => (
-              <li className="text-sm" key={index}>
-                {strength}
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="space-y-4 rounded-2xl border border-[#F97316] bg-[#FFF7ED]/50 p-6">
-          <p className="flex items-center gap-2 text-lg font-bold text-[#7C2D12]">
-            <TriangleAlert className="h-5 w-5 text-[#EA580C]" />
-            보완하면 좋을 점
-          </p>
-          <ul className="flex list-disc flex-col gap-2 pl-5 text-[#9A3412] marker:text-[#F97316]">
-            {feedback.weaknesses.map((weakness, index) => (
-              <li className="text-sm" key={index}>
-                {weakness}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
-      <div className="space-y-4 rounded-2xl border border-[#A855F7] bg-[#FAF5FF] p-6">
-        <p className="flex items-center gap-2 text-lg font-bold text-[#9333EA]">
-          <Lightbulb className="h-5 w-5 text-[#9333EA]" />
-          도움이 될 팁
-        </p>
-        <ul className="flex list-disc flex-col gap-2 pl-5 text-[#6B21A8] marker:text-[#b064ee]">
-          {feedback.suggestions.map((suggestion, index) => (
-            <li className="text-sm" key={index}>
-              {suggestion}
-            </li>
-          ))}
-        </ul>
-      </div>
+
+      {isFeedbackLoading || !feedback ? (
+        <LoadingContent message={getStatusMessage(assessmentStatus)} />
+      ) : isInsufficientAnswer ? (
+        <InsufficientAnswerFeedbackContent />
+      ) : (
+        <FeedbackContent feedback={feedback} />
+      )}
     </section>
   );
 };
 
 export default FeedbackSection;
+
+const LoadingContent = ({ message }: { message: string }) => (
+  <div className="flex flex-col items-center gap-3 rounded-lg bg-primary/5 p-4">
+    <Loader2 className="h-6 w-6 animate-spin text-primary" />
+    <p className="text-sm font-medium text-primary">{message}</p>
+  </div>
+);
+
+const InsufficientAnswerFeedbackContent = () => (
+  <div className="flex flex-col items-center gap-4 rounded-2xl border border-[#6366F1] bg-linear-to-br from-[#EEF2FF] to-[#E0E7FF] p-8">
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[#6366F1]/10">
+      <BookOpen className="h-8 w-8 text-[#6366F1]" />
+    </div>
+    <div className="text-center">
+      <p className="text-lg font-bold text-[#3730A3]">조금 더 학습하고 다시 도전해보세요!</p>
+      <p className="mt-2 text-sm text-[#4338CA]">
+        질문의 핵심 키워드를 파악하고, 가이드를 참고해서 답변해보세요.
+      </p>
+    </div>
+  </div>
+);
+
+const FeedbackContent = ({ feedback }: { feedback: GetFeedbackResponseDTO }) => (
+  <>
+    <div className="grid grid-cols-2 gap-6">
+      <div className="space-y-4 rounded-2xl border border-[#22C55E] bg-[#F0FDF4]/50 p-6">
+        <p className="flex items-center gap-2 text-lg font-bold text-[#14532D]">
+          <CircleCheck className="h-5 w-5 text-[#16A34A]" />
+          정확한 개념 설명
+        </p>
+        <ul className="flex list-disc flex-col gap-2 pl-5 text-dark-green marker:text-[#22C55E]">
+          {feedback.strengths.map((strength, index) => (
+            <li className="text-sm" key={index}>
+              {strength}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="space-y-4 rounded-2xl border border-[#F97316] bg-[#FFF7ED]/50 p-6">
+        <p className="flex items-center gap-2 text-lg font-bold text-[#7C2D12]">
+          <TriangleAlert className="h-5 w-5 text-[#EA580C]" />
+          보완하면 좋을 점
+        </p>
+        <ul className="flex list-disc flex-col gap-2 pl-5 text-[#9A3412] marker:text-[#F97316]">
+          {feedback.weaknesses.map((weakness, index) => (
+            <li className="text-sm" key={index}>
+              {weakness}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+    <div className="space-y-4 rounded-2xl border border-[#A855F7] bg-[#FAF5FF] p-6">
+      <p className="flex items-center gap-2 text-lg font-bold text-[#9333EA]">
+        <Lightbulb className="h-5 w-5 text-[#9333EA]" />
+        도움이 될 팁
+      </p>
+      <ul className="flex list-disc flex-col gap-2 pl-5 text-[#6B21A8] marker:text-[#b064ee]">
+        {feedback.suggestions.map((suggestion, index) => (
+          <li className="text-sm" key={index}>
+            {suggestion}
+          </li>
+        ))}
+      </ul>
+    </div>
+  </>
+);

--- a/apps/fe/src/features/learning/components/question/feedback-section.tsx
+++ b/apps/fe/src/features/learning/components/question/feedback-section.tsx
@@ -2,7 +2,18 @@ import { ANSWER_PHASE, useAnswerFlow } from '@/features/learning/lib/contexts/an
 import { ASSESSMENT_STATUS, type AssessmentStatus } from '@repo/shared/constants/learning';
 import type { GetFeedbackResponseDTO } from '@repo/shared/types/learning';
 
-import { BookOpen, Bot, CircleCheck, Lightbulb, Loader2, TriangleAlert } from 'lucide-react';
+import {
+  BookOpen,
+  Bot,
+  CircleCheck,
+  Info,
+  Lightbulb,
+  Loader2,
+  type LucideIcon,
+  Search,
+  ThumbsUp,
+  TriangleAlert,
+} from 'lucide-react';
 
 const ASSESSMENT_STATUS_MESSAGE: Record<string, string> = {
   [ASSESSMENT_STATUS.QUEUED]: '평가 대기 중...',
@@ -75,45 +86,58 @@ const InsufficientAnswerFeedbackContent = () => (
 const FeedbackContent = ({ feedback }: { feedback: GetFeedbackResponseDTO }) => (
   <>
     <div className="grid grid-cols-2 gap-6">
-      <div className="space-y-4 rounded-2xl border border-[#22C55E] bg-[#F0FDF4]/50 p-6">
+      <div className="flex flex-col gap-4 rounded-2xl border border-[#22C55E] bg-[#F0FDF4]/50 p-6">
         <p className="flex items-center gap-2 text-lg font-bold text-[#14532D]">
           <CircleCheck className="h-5 w-5 text-[#16A34A]" />
           정확한 개념 설명
         </p>
-        <ul className="flex list-disc flex-col gap-2 pl-5 text-dark-green marker:text-[#22C55E]">
-          {feedback.strengths.map((strength, index) => (
-            <li className="text-sm" key={index}>
-              {strength}
-            </li>
-          ))}
-        </ul>
+        {feedback.strengths.length > 0 ? (
+          <ul className="flex list-disc flex-col gap-2 pl-5 text-dark-green marker:text-[#22C55E]">
+            {feedback.strengths.map((strength, index) => (
+              <li key={index}>{strength}</li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyListItem message="핵심 개념에 대해 더 구체적으로 설명해보세요" icon={Search} />
+        )}
       </div>
-      <div className="space-y-4 rounded-2xl border border-[#F97316] bg-[#FFF7ED]/50 p-6">
+      <div className="flex flex-col gap-4 rounded-2xl border border-[#F97316] bg-[#FFF7ED]/50 p-6">
         <p className="flex items-center gap-2 text-lg font-bold text-[#7C2D12]">
           <TriangleAlert className="h-5 w-5 text-[#EA580C]" />
           보완하면 좋을 점
         </p>
-        <ul className="flex list-disc flex-col gap-2 pl-5 text-[#9A3412] marker:text-[#F97316]">
-          {feedback.weaknesses.map((weakness, index) => (
-            <li className="text-sm" key={index}>
-              {weakness}
-            </li>
-          ))}
-        </ul>
+        {feedback.weaknesses.length > 0 ? (
+          <ul className="flex list-disc flex-col gap-2 pl-5 text-[#9A3412] marker:text-[#F97316]">
+            {feedback.weaknesses.map((weakness, index) => (
+              <li key={index}>{weakness}</li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyListItem message="특별히 보완할 점이 없어요!" icon={ThumbsUp} />
+        )}
       </div>
     </div>
-    <div className="space-y-4 rounded-2xl border border-[#A855F7] bg-[#FAF5FF] p-6">
+    <div className="flex flex-col gap-4 rounded-2xl border border-[#A855F7] bg-[#FAF5FF] p-6">
       <p className="flex items-center gap-2 text-lg font-bold text-[#9333EA]">
         <Lightbulb className="h-5 w-5 text-[#9333EA]" />
         도움이 될 팁
       </p>
-      <ul className="flex list-disc flex-col gap-2 pl-5 text-[#6B21A8] marker:text-[#b064ee]">
-        {feedback.suggestions.map((suggestion, index) => (
-          <li className="text-sm" key={index}>
-            {suggestion}
-          </li>
-        ))}
-      </ul>
+      {feedback.suggestions.length > 0 ? (
+        <ul className="flex list-disc flex-col gap-2 pl-5 text-[#6B21A8] marker:text-[#b064ee]">
+          {feedback.suggestions.map((suggestion, index) => (
+            <li key={index}>{suggestion}</li>
+          ))}
+        </ul>
+      ) : (
+        <EmptyListItem message="추가로 드릴 팁이 없어요" icon={Info} />
+      )}
     </div>
   </>
+);
+
+const EmptyListItem = ({ message, icon: Icon }: { message: string; icon: LucideIcon }) => (
+  <div className="flex flex-1 items-center justify-center gap-2">
+    <Icon className="h-4 w-4" />
+    {message}
+  </div>
 );

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -83,6 +83,14 @@ const FloatingStepBar = () => {
     });
   };
 
+  const isInsufficientAnswer = Boolean(
+    feedback &&
+    ((feedback.strengths.length === 0 &&
+      feedback.weaknesses.length === 0 &&
+      feedback.suggestions.length === 0) ||
+      feedback.overallScore === 0),
+  );
+
   return (
     <ActionBar>
       <ActionBar.Button onClick={handleEndLearning} withDivider>
@@ -92,7 +100,7 @@ const FloatingStepBar = () => {
         <>
           <ActionBar.Button
             onClick={handleDeepDive}
-            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || feedback?.overallScore === 0}
+            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || isInsufficientAnswer}
             className="flex items-center gap-2"
           >
             <Binoculars className="hidden h-4 w-4 sm:block" />

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -18,7 +18,8 @@ const FloatingStepBar = () => {
   const sessionId = useLearningSession((state) => state.sessionId);
   const question = useLearningSession((state) => state.question);
 
-  const { phase, setPhase, sttText, setAnswerId, answerId, recordingTime, reset } = useAnswerFlow();
+  const { phase, setPhase, sttText, setAnswerId, answerId, recordingTime, reset, feedback } =
+    useAnswerFlow();
 
   const [rewardData, setRewardData] = useState<FinishSessionResponseDTO | null>(null);
   const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
@@ -91,7 +92,7 @@ const FloatingStepBar = () => {
         <>
           <ActionBar.Button
             onClick={handleDeepDive}
-            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE}
+            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || feedback?.overallScore === 0}
             className="flex items-center gap-2"
           >
             <Binoculars className="hidden h-4 w-4 sm:block" />

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -18,8 +18,16 @@ const FloatingStepBar = () => {
   const sessionId = useLearningSession((state) => state.sessionId);
   const question = useLearningSession((state) => state.question);
 
-  const { phase, setPhase, sttText, setAnswerId, answerId, recordingTime, reset, feedback } =
-    useAnswerFlow();
+  const {
+    phase,
+    setPhase,
+    sttText,
+    setAnswerId,
+    answerId,
+    recordingTime,
+    reset,
+    isInsufficientAnswer,
+  } = useAnswerFlow();
 
   const [rewardData, setRewardData] = useState<FinishSessionResponseDTO | null>(null);
   const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
@@ -82,14 +90,6 @@ const FloatingStepBar = () => {
       useLearningSession.getState().setQuestion({ ...data, sessionId });
     });
   };
-
-  const isInsufficientAnswer = Boolean(
-    feedback &&
-    ((feedback.strengths.length === 0 &&
-      feedback.weaknesses.length === 0 &&
-      feedback.suggestions.length === 0) ||
-      feedback.overallScore === 0),
-  );
 
   return (
     <ActionBar>

--- a/apps/fe/src/features/learning/lib/contexts/answer-flow-context.tsx
+++ b/apps/fe/src/features/learning/lib/contexts/answer-flow-context.tsx
@@ -23,6 +23,10 @@ type AnswerFlowState = {
   recordingTime: number;
 };
 
+type ComputedAnswerFlowState = AnswerFlowState & {
+  isInsufficientAnswer: boolean;
+};
+
 type AnswerFlowActions = {
   setPhase: (phase: AnswerPhase) => void;
   setSttText: (text: string) => void;
@@ -33,7 +37,7 @@ type AnswerFlowActions = {
   reset: () => void;
 };
 
-type AnswerFlowContextType = AnswerFlowState & AnswerFlowActions;
+type AnswerFlowContextType = ComputedAnswerFlowState & AnswerFlowActions;
 
 const initialState: AnswerFlowState = {
   phase: ANSWER_PHASE.IDLE,
@@ -81,10 +85,19 @@ export const AnswerFlowProvider = ({ children }: AnswerFlowProviderProps) => {
     setState(initialState);
   }, []);
 
+  const isInsufficientAnswer = Boolean(
+    state.feedback &&
+    ((state.feedback.strengths.length === 0 &&
+      state.feedback.weaknesses.length === 0 &&
+      state.feedback.suggestions.length === 0) ||
+      state.feedback.overallScore === 0),
+  );
+
   return (
     <AnswerFlowContext.Provider
       value={{
         ...state,
+        isInsufficientAnswer,
         setPhase,
         setSttText,
         setFeedback,


### PR DESCRIPTION
## 🔗 관련 이슈

- close #132

<br/>

## 🔍 작업 내용

### floating-step-bar.tsx

- `isInsufficientAnswer` 변수 추가: 피드백 점수가 0이거나 strengths/weaknesses/suggestions가 모두 빈 배열인 경우 불충분한 답변으로 판단
- 딥다이브 버튼의 `disabled` 조건에 `isInsufficientAnswer` 추가하여 불충분한 답변일 경우 버튼 비활성화

### feedback-section.tsx

- `isInsufficientAnswer` 조건 추가: 점수 0점 또는 모든 피드백 필드가 빈 배열인 경우 판별
- `InsufficientAnswerFeedbackContent` 컴포넌트 추가: 불충분한 답변일 경우 "조금 더 학습하고 다시 도전해보세요!" 대체 UI 표시
- `EmptyListItem` 컴포넌트 추가: 특정 필드(strengths, weaknesses, suggestions)가 비어있을 경우 개별 대체 문구 표시
- `LoadingContent`, `FeedbackContent` 컴포넌트 분리로 코드 가독성 개선

<br/>

## 📷 스크린샷
<table>
  <thead>
    <tr>
      <th>불충분한 답변 (0점 또는 빈 배열)</th>
      <th>특정 필드만 비어있는 경우</th>
      <th>딥다이브 버튼 비활성화</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
          <img width="1918" height="930" alt="스크린샷 2026-01-27 오전 8 48 48" src="https://github.com/user-attachments/assets/3b5090d1-6b92-471c-8976-bcef51e2201c" />
      </td>
      <td>
          <img width="1918" height="930" alt="스크린샷 2026-01-27 오전 8 48 35" src="https://github.com/user-attachments/assets/bd28c6d5-4cc3-42c4-a82c-a22b01769c8f" />
      </td>
      <td>
          <video src="https://github.com/user-attachments/assets/4ebac899-4efb-49e2-a331-9ba68426957c.mp4" />
      </td>
    </tr>
  </tbody>
</table>

> [!NOTE]
> 실제 로직에서는 모든 필드(strengths, weaknesses, suggestions)가 비어있으면 "불충분한 답변"으로 판단하여 1번 UI만 표시됩니다. 따라서 정상적인 흐름에서는 2번 UI가 노출되지 않습니다.
> 스크린샷에서는 각 UI가 어떻게 보이는지 한눈에 확인할 수 있도록 조건을 임시로 수정하여 캡처했습니다.

<br/>


## ✅ 체크리스트

- [x]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [x]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [ ]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: `5분`

<br/>

## 📄 추가 전달 사항

- 피드백 점수가 0점이거나, strengths/weaknesses/suggestions가 모두 빈 배열인 경우를 "불충분한 답변"으로 정의했습니다.
- 각 필드가 개별적으로 비어있는 경우에도 대체 문구가 표시되도록 처리했습니다.