### PR TITLE
Feat/#133 음성 답변 UI/ux 개선

### DIFF
--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -13,13 +13,15 @@ const AnswerSection = () => {
       <h3 className="sr-only">음성 인식 결과</h3>
       <p className="text-xl font-bold">나의 답변</p>
       <div className="mt-4 rounded-md">
-        {isSttLoading || !sttText ? (
+        {isSttLoading ? (
           <div className="flex flex-col items-center gap-3">
             <div className="loader-dots" />
             <p className="text-dark-gray">AI가 음성을 텍스트로 변환하고 있어요</p>
           </div>
-        ) : (
+        ) : sttText ? (
           <p>{sttText}</p>
+        ) : (
+          <p>음성이 인식되지 않았어요. 다시 녹음해 주세요</p>
         )}
       </div>
     </section>

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -111,7 +111,7 @@ const FloatingStepBar = () => {
             다음 질문으로 건너뛰기
           </ActionBar.Button>
           <ActionBar.PrimaryButton
-            disabled={phase !== ANSWER_PHASE.STT_DONE}
+            disabled={phase !== ANSWER_PHASE.STT_DONE || !sttText}
             onClick={handleSubmitAnswer}
           >
             답변 제출하기


### PR DESCRIPTION
## 🔗 관련 이슈

- close #133

<br/>

## 🔍 작업 내용

### `apps/fe/src/features/learning/components/question/answer-section.tsx`

- 음성 인식(STT) 결과가 빈 문자열일 때 **"음성이 인식되지 않았어요. 다시 녹음해 주세요"** 안내 문구를 표시하도록 조건부 렌더링 분기 추가
- 기존에는 `isSttLoading || !sttText` 조건으로 로딩 상태와 빈 결과를 동일하게 처리했으나, 로딩 중 / 정상 결과 / 인식 실패 3가지 상태로 분리

### `apps/fe/src/features/learning/components/question/floating-step-bar.tsx`

- **답변 제출하기** 버튼의 `disabled` 조건에 `!sttText`를 추가하여 음성 인식 실패(빈 텍스트) 시 제출 불가능하도록 변경

<br/>

## 📷 스크린샷


https://github.com/user-attachments/assets/fc98f9b6-2cb7-4c69-9450-c6aea6157cee


<br/>

## ✅ 체크리스트

- [x]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [x]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: `5분`
- STT 결과가 빈 문자열일 때의 분기 처리 방식이 적절한지 확인 부탁드립니다!
> 