### PR TITLE
Refactor/#138 세션 카운팅 관련 로직 수정

### DIFF
--- a/apps/be/src/learning/sessions/repository/sessions.repository.ts
+++ b/apps/be/src/learning/sessions/repository/sessions.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '@/infra/database/prisma.service';
-import { Prisma, PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class SessionsRepository {
@@ -10,8 +10,10 @@ export class SessionsRepository {
   /**
    * 세션 ID로 세션 조회
    */
-  async findById(id: number) {
-    return this.prisma.session.findUnique({
+  async findById(id: number, tx?: Prisma.TransactionClient) {
+    const client = tx ?? this.prisma;
+
+    return client.session.findUnique({
       where: { id },
     });
   }
@@ -33,14 +35,22 @@ export class SessionsRepository {
 
   /**
    * 새 세션 생성
+   * - createSession 단계에서 첫 질문이 이미 제공되므로
+   * - currentQuestionCount는 1부터 시작한다.
    */
-  async createSession(data: { userId: number; category: string; difficulty: string }) {
-    return this.prisma.session.create({
+  async createSession(
+    data: { userId: number; category: string; difficulty: string },
+    tx?: Prisma.TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+
+    return client.session.create({
       data: {
         userId: data.userId,
         status: 'ACTIVE',
         category: data.category,
         difficulty: data.difficulty,
+        currentQuestionCount: 1,
       },
     });
   }
@@ -57,9 +67,13 @@ export class SessionsRepository {
 
   /**
    * 세션 완료 처리
+   * - getNextQuestion 등에서는 직접 호출하지 않고
+   * - finishSession에서 단일 책임으로 호출
    */
-  async completeSession(id: number) {
-    return this.prisma.session.update({
+  async completeSession(id: number, tx?: Prisma.TransactionClient) {
+    const client = tx ?? this.prisma;
+
+    return client.session.update({
       where: { id },
       data: {
         status: 'COMPLETED',
@@ -70,85 +84,19 @@ export class SessionsRepository {
 
   /**
    * 세션 내 질문 count 증가 처리
+   * - 트랜잭션 대응
+   * - 증가된 session row를 반환
    */
-  async incrementQuestionCount(sessionId: number): Promise<void> {
-    await this.prisma.session.update({
+  async incrementQuestionCount(sessionId: number, tx?: Prisma.TransactionClient) {
+    const client = tx ?? this.prisma;
+
+    return client.session.update({
       where: { id: sessionId },
       data: {
         currentQuestionCount: {
           increment: 1,
         },
       },
-    });
-  }
-
-  /**
-   * 사용자 답변 저장
-   */
-  async saveAnswer(data: {
-    sessionId: number;
-    userId: number;
-    questionId: number;
-    answerText: string;
-    timeSpentSec: number;
-    overallScore?: number;
-    feedbackJson?: Prisma.InputJsonValue;
-  }) {
-    return this.prisma.userAnswer.create({
-      data: {
-        sessionId: data.sessionId,
-        userId: data.userId,
-        questionId: data.questionId,
-        answerText: data.answerText,
-        timeSpentSec: data.timeSpentSec,
-        overallScore: data.overallScore ?? 0,
-        feedbackJson: data.feedbackJson ?? {},
-      },
-    });
-  }
-
-  /**
-   * 세션의 모든 답변 조회
-   */
-  async findAnswersBySessionId(sessionId: number) {
-    return this.prisma.userAnswer.findMany({
-      where: { sessionId },
-      include: {
-        question: {
-          select: {
-            id: true,
-            content: true,
-            category: true,
-            difficulty: true,
-          },
-        },
-      },
-      orderBy: {
-        createdAt: 'asc',
-      },
-    });
-  }
-
-  /**
-   * 답변 ID로 답변 조회
-   */
-  async findAnswerById(id: number) {
-    return this.prisma.userAnswer.findUnique({
-      where: { id },
-      include: {
-        question: true,
-        session: true,
-      },
-    });
-  }
-
-  /**
-   * 답변 업데이트
-   */
-  async updateAnswer(id: number, data: Prisma.UserAnswerUpdateInput) {
-    return this.prisma.userAnswer.update({
-      where: { id },
-      data,
     });
   }
 

--- a/apps/be/src/learning/sessions/services/deep-dive.service.ts
+++ b/apps/be/src/learning/sessions/services/deep-dive.service.ts
@@ -81,7 +81,7 @@ export class DeepDiveService {
     const guide = this.guideBuilder.build(extraQuestion.mustInclude);
 
     return {
-      currentQuestionCount: session.currentQuestionCount + 1,
+      currentQuestionCount: session.currentQuestionCount,
       remainedCredit,
       question: {
         extraQuestionId: extraQuestion.id,

--- a/apps/be/src/learning/sessions/services/deep-dive.service.ts
+++ b/apps/be/src/learning/sessions/services/deep-dive.service.ts
@@ -57,8 +57,6 @@ export class DeepDiveService {
           sessionId,
           parentAnswerId: answer.id,
           answerContent: answer.answerText,
-          category: answer.category,
-          difficulty: answer.difficulty,
         });
 
         await this.userCreditsRepository.consume(

--- a/apps/be/src/learning/sessions/services/deep-dive.service.ts
+++ b/apps/be/src/learning/sessions/services/deep-dive.service.ts
@@ -35,22 +35,14 @@ export class DeepDiveService {
     }
 
     // 크레딧 확인
-    // NOTE: 테스트를 위해서 일단 주석처리했습니다. 실 사용시 주석 해제하면 됩니다.
     const remainedCredit = await this.userCreditsRepository.getTotalCredit(userId);
-    if (remainedCredit <= 0) {
-      /*await this.sessionsService.finishSession(sessionId);
-      throw new BadRequestException({
-        code: 'CREDIT_EXHAUSTED',
-        message: '잔여 크레딧이 부족합니다.',
-      });*/
-    }
 
     const answer = await this.answerRepository.findByIdWithContext(answerId);
     if (!answer || answer.sessionId !== sessionId) {
       throw new BadRequestException('ANSWER_NOT_FOUND');
     }
 
-    // DeepDive 질문 생성 + 상태 변경 (트랜잭션)
+    // DeepDive 질문 생성
     const { extraQuestion, updatedSession } = await this.sessionsRepository.transaction(
       async (tx) => {
         const extraQuestion = await this.createExtraQuestionUseCase.execute({
@@ -59,20 +51,13 @@ export class DeepDiveService {
           answerContent: answer.answerText,
         });
 
-        await this.userCreditsRepository.consume(
-          userId,
-          'EXTRA_QUESTION_CONSUME', // TODO: Credit Reason은 Enum으로 정의하는거 고려
-          1,
-          tx,
-        );
-
         const updatedSession = await this.sessionsRepository.incrementQuestionCount(sessionId, tx);
 
         return { extraQuestion, updatedSession };
       },
     );
 
-    return this.present(extraQuestion, updatedSession, remainedCredit - 1);
+    return this.present(extraQuestion, updatedSession, remainedCredit);
   }
 
   private present(extraQuestion: any, session: any, remainedCredit: number) {

--- a/apps/be/src/learning/sessions/services/deep-dive.service.ts
+++ b/apps/be/src/learning/sessions/services/deep-dive.service.ts
@@ -3,9 +3,11 @@ import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { CreateExtraQuestionUseCase } from '@/modules/question-provider/application/create-extra-question.usecase';
 import { USER_ANSWER_REPOSITORY } from '@/modules/question-provider/infra/ports/user-answer.repository.port';
 import type { UserAnswerRepositoryPort } from '@/modules/question-provider/infra/ports/user-answer.repository.port';
+import { UserCreditsRepository } from '@/users/credits/user-credits.repository';
 
 import { SessionsRepository } from '../repository/sessions.repository';
 import { GuideBuilderService } from './guide-builder.service';
+import { SessionsService } from './sessions.service';
 
 @Injectable()
 export class DeepDiveService {
@@ -16,6 +18,8 @@ export class DeepDiveService {
 
     @Inject(USER_ANSWER_REPOSITORY)
     private readonly answerRepository: UserAnswerRepositoryPort,
+    private readonly sessionsService: SessionsService,
+    private readonly userCreditsRepository: UserCreditsRepository,
   ) {}
 
   async execute(params: { userId: number; sessionId: number; answerId: number }) {
@@ -26,21 +30,51 @@ export class DeepDiveService {
       throw new BadRequestException('INVALID_SESSION');
     }
 
-    const answer = await this.answerRepository.findById(answerId);
+    if (session.completedAt) {
+      throw new BadRequestException('SESSION_COMPLETED');
+    }
+
+    // 크레딧 확인
+    // NOTE: 테스트를 위해서 일단 주석처리했습니다. 실 사용시 주석 해제하면 됩니다.
+    const remainedCredit = await this.userCreditsRepository.getTotalCredit(userId);
+    if (remainedCredit <= 0) {
+      /*await this.sessionsService.finishSession(sessionId);
+      throw new BadRequestException({
+        code: 'CREDIT_EXHAUSTED',
+        message: '잔여 크레딧이 부족합니다.',
+      });*/
+    }
+
+    const answer = await this.answerRepository.findByIdWithContext(answerId);
     if (!answer || answer.sessionId !== sessionId) {
       throw new BadRequestException('ANSWER_NOT_FOUND');
     }
 
-    const extraQuestion = await this.createExtraQuestionUseCase.execute({
-      sessionId,
-      parentAnswerId: answer.id,
-      answerContent: answer.answerText,
-    });
+    // DeepDive 질문 생성 + 상태 변경 (트랜잭션)
+    const { extraQuestion, updatedSession } = await this.sessionsRepository.transaction(
+      async (tx) => {
+        const extraQuestion = await this.createExtraQuestionUseCase.execute({
+          sessionId,
+          parentAnswerId: answer.id,
+          answerContent: answer.answerText,
+          category: answer.category,
+          difficulty: answer.difficulty,
+        });
 
-    // 현재 질문 count 증가
-    await this.sessionsRepository.incrementQuestionCount(sessionId);
+        await this.userCreditsRepository.consume(
+          userId,
+          'EXTRA_QUESTION_CONSUME', // TODO: Credit Reason은 Enum으로 정의하는거 고려
+          1,
+          tx,
+        );
 
-    return this.present(extraQuestion, session, 10);
+        const updatedSession = await this.sessionsRepository.incrementQuestionCount(sessionId, tx);
+
+        return { extraQuestion, updatedSession };
+      },
+    );
+
+    return this.present(extraQuestion, updatedSession, remainedCredit - 1);
   }
 
   private present(extraQuestion: any, session: any, remainedCredit: number) {

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -37,6 +37,14 @@ export class SessionsService {
     private readonly streakCalculator: StreakCalculatorService,
   ) {}
 
+  /**
+   * 세션 생성 + 첫 질문 제공
+   *
+   * 규칙:
+   * - 세션 생성과 첫 질문 비용 차감은 하나의 트랜잭션
+   * - createSession 시점에 currentQuestionCount = 1
+   */
+
   async createSession(userId: number, dto: CreateSessionDto) {
     /**
      * 이미 진행 중인 세션 체크
@@ -58,24 +66,49 @@ export class SessionsService {
     }
 
     /**
+     * 유저의 잔여 크레딧 조회
+     */
+
+    const remainedCredit = await this.userCreditsRepository.getTotalCredit(userId);
+
+    // NOTE: 테스트를 위해서 일단 주석처리했습니다. 실 사용시 주석 해제하면 됩니다.
+    if (remainedCredit <= 0) {
+      //throw new BadRequestException('잔여 크레딧이 부족합니다.');
+    }
+
+    /**
+     * 세션 생성 + 첫 질문 비용 차감 (원자적 처리)
+     */
+    const session = await this.sessionsRepository.transaction(async (tx) => {
+      const createdSession = await this.sessionsRepository.createSession(
+        {
+          userId,
+          category: dto.category,
+          difficulty: dto.difficulty,
+        },
+        tx,
+      );
+
+      await this.userCreditsRepository.consume(
+        userId,
+        'QUESTION_CONSUME', // TODO: CreditReason enum으로 교체
+        1,
+        tx,
+      );
+
+      return createdSession;
+    });
+
+    /**
      * mustInclude 키워드를 기반으로
      * 사용자에게 제공할 답변 가이드를 생성
      */
     const guide = this.guideBuilder.build(question.mustInclude);
 
-    /**
-     * 세션 생성 (Repository 타입과 정확히 일치)
-     */
-    const session = await this.sessionsRepository.createSession({
-      userId,
-      category: dto.category,
-      difficulty: dto.difficulty,
-    });
-
     return {
       sessionId: session.id,
-      currentQuestionCount: 1,
-      remainedCredit: 20,
+      currentQuestionCount: session.currentQuestionCount,
+      remainedCredit: remainedCredit - 1,
       question: {
         questionId: question.questionId,
         content: question.content,
@@ -86,6 +119,14 @@ export class SessionsService {
       },
     };
   }
+
+  /**
+   * 다음 질문 조회
+   *
+   * 규칙:
+   * - 질문 제공 시점에 크레딧 차감 + questionCount 증가
+   * - 종료 조건 감지만 담당 (종료 처리는 finishSession에 위임)
+   */
 
   async getNextQuestion(sessionId: number) {
     /**
@@ -108,11 +149,16 @@ export class SessionsService {
     /**
      * 3. 유저 잔여 크레딧 조회 (UserCredit ledger SUM)
      */
-    /*const remainedCredit = await this.userCreditsRepository.getTotalCredit(session.userId);
+    const remainedCredit = await this.userCreditsRepository.getTotalCredit(session.userId);
 
+    // NOTE: 테스트를 위해서 일단 주석처리했습니다. 실 사용시 주석 해제하면 됩니다.
     if (remainedCredit <= 0) {
-      throw new BadRequestException('잔여 크레딧이 부족합니다.');
-    }*/
+      //await this.finishSession(sessionId);
+      /*throw new BadRequestException({
+        code: 'CREDIT_EXHAUSTED',
+        message: '잔여 크레딧이 부족하여 세션이 종료되었습니다.',
+      });*/
+    }
 
     const question = await this.questionService.pickOne(
       session.category as Domain,
@@ -123,20 +169,20 @@ export class SessionsService {
       /**
        * 더 이상 질문이 없다면 세션 종료 처리
        */
-      /**
-       * TODO: 세션 종료 처리
-       *
-       * - status를 COMPLETED로 변경
-       * - completedAt 기록
-       * - 최종 점수 / XP 계산 (향후)
-       * - 세션 요약 리포트 생성 (향후)
-       * - 더이상 질문이 없다는 건, 알려줘야하지 않을까?
-       */
+
+      await this.finishSession(sessionId);
+      throw new BadRequestException({
+        code: 'SESSION_COMPLETED',
+        message: '더 이상 제공할 질문이 없어 세션이 종료되었습니다.',
+      });
     }
 
     // 질문 제공 후 증가
-    await this.sessionsRepository.incrementQuestionCount(sessionId);
+    const updatedSession = await this.sessionsRepository.transaction(async (tx) => {
+      await this.userCreditsRepository.consume(session.userId, 'QUESTION_CONSUME', 1, tx);
 
+      return this.sessionsRepository.incrementQuestionCount(sessionId, tx);
+    });
     /**
      * 5. 답변 가이드 생성
      */
@@ -146,8 +192,8 @@ export class SessionsService {
      * 6. 응답 반환
      */
     return {
-      currentQuestionCount: session.currentQuestionCount + 1,
-      remainedCredit: 20,
+      currentQuestionCount: updatedSession.currentQuestionCount,
+      remainedCredit: remainedCredit - 1,
       question: {
         questionId: question.questionId,
         content: question.content,
@@ -161,6 +207,7 @@ export class SessionsService {
 
   /**
    * 세션 종료 및 리워드(XP, 레벨, 스트릭) 정산을 수행하는 메인 메서드
+   * - 세션 종료는 반드시 이 메서드를 통해서만 수행
    */
   async finishSession(sessionId: number): Promise<FinishSessionResponseDto> {
     // 1. 검증 및 데이터 로드

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -71,11 +71,6 @@ export class SessionsService {
 
     const remainedCredit = await this.userCreditsRepository.getTotalCredit(userId);
 
-    // NOTE: 테스트를 위해서 일단 주석처리했습니다. 실 사용시 주석 해제하면 됩니다.
-    if (remainedCredit <= 0) {
-      //throw new BadRequestException('잔여 크레딧이 부족합니다.');
-    }
-
     /**
      * 세션 생성 + 첫 질문 비용 차감 (원자적 처리)
      */
@@ -86,13 +81,6 @@ export class SessionsService {
           category: dto.category,
           difficulty: dto.difficulty,
         },
-        tx,
-      );
-
-      await this.userCreditsRepository.consume(
-        userId,
-        'QUESTION_CONSUME', // TODO: CreditReason enum으로 교체
-        1,
         tx,
       );
 
@@ -108,7 +96,7 @@ export class SessionsService {
     return {
       sessionId: session.id,
       currentQuestionCount: session.currentQuestionCount,
-      remainedCredit: remainedCredit - 1,
+      remainedCredit: remainedCredit,
       question: {
         questionId: question.questionId,
         content: question.content,
@@ -151,15 +139,6 @@ export class SessionsService {
      */
     const remainedCredit = await this.userCreditsRepository.getTotalCredit(session.userId);
 
-    // NOTE: 테스트를 위해서 일단 주석처리했습니다. 실 사용시 주석 해제하면 됩니다.
-    if (remainedCredit <= 0) {
-      //await this.finishSession(sessionId);
-      /*throw new BadRequestException({
-        code: 'CREDIT_EXHAUSTED',
-        message: '잔여 크레딧이 부족하여 세션이 종료되었습니다.',
-      });*/
-    }
-
     const question = await this.questionService.pickOne(
       session.category as Domain,
       session.difficulty as Difficulty,
@@ -179,8 +158,6 @@ export class SessionsService {
 
     // 질문 제공 후 증가
     const updatedSession = await this.sessionsRepository.transaction(async (tx) => {
-      await this.userCreditsRepository.consume(session.userId, 'QUESTION_CONSUME', 1, tx);
-
       return this.sessionsRepository.incrementQuestionCount(sessionId, tx);
     });
     /**
@@ -193,7 +170,7 @@ export class SessionsService {
      */
     return {
       currentQuestionCount: updatedSession.currentQuestionCount,
-      remainedCredit: remainedCredit - 1,
+      remainedCredit: remainedCredit,
       question: {
         questionId: question.questionId,
         content: question.content,

--- a/apps/be/src/modules/question-provider/application/create-extra-question.usecase.ts
+++ b/apps/be/src/modules/question-provider/application/create-extra-question.usecase.ts
@@ -42,8 +42,15 @@ export class CreateExtraQuestionUseCase {
 
     /**
      * 부모 질문 컨텍스트 해석
+     * 부모 depth 조회
+     * - Normal Question → 0
+     * - ExtraQuestion → parent.depth
      */
     const parentContext = await this.questionContextResolver.resolveByAnswerId(parentAnswerId);
+    const parentDepth =
+      await this.extraQuestionRepository.findParentDepthByAnswerId(parentAnswerId);
+
+    const nextDepth = parentDepth + 1;
 
     /**
      * 꼬리질문 생성 (LLM 호출)
@@ -66,7 +73,7 @@ export class CreateExtraQuestionUseCase {
       category: parentContext.category,
       difficulty: parentContext.difficulty,
       timeLimitSec: 180,
-      depth: parentContext.depth + 1,
+      depth: nextDepth,
     });
 
     return extraQuestion;

--- a/apps/be/src/modules/question-provider/infra/ports/extra-question.repository.port.ts
+++ b/apps/be/src/modules/question-provider/infra/ports/extra-question.repository.port.ts
@@ -2,6 +2,10 @@ import { Category, Difficulty } from '@prisma/client';
 
 import type { ExtraQuestionModel } from '../../domain/models/extra-question.model';
 
+export interface ParentDepthContext {
+  parentDepth: number; // Question이면 0, ExtraQuestion이면 해당 depth
+}
+
 export interface ExtraQuestionRepositoryPort {
   /**
    * ExtraQuestion 단건 조회
@@ -13,6 +17,13 @@ export interface ExtraQuestionRepositoryPort {
    * (중복 생성 방지용)
    */
   findByParentAnswerId(parentAnswerId: number): Promise<ExtraQuestionModel | null>;
+
+  /**
+   * 부모 Answer의 질문 depth 조회
+   * - Normal Question → 0
+   * - ExtraQuestion → 해당 depth
+   */
+  findParentDepthByAnswerId(parentAnswerId: number): Promise<number>;
 
   /**
    * ExtraQuestion 저장

--- a/apps/be/src/modules/question-provider/infra/ports/user-answer.repository.port.ts
+++ b/apps/be/src/modules/question-provider/infra/ports/user-answer.repository.port.ts
@@ -1,3 +1,5 @@
+import { Category, Difficulty } from '@prisma/client';
+
 /**
  * TODO:
  * - 이 Port의 실제 책임 위치는 평가모듈 또는 user모듈이 적절함.
@@ -17,6 +19,17 @@ export interface UserAnswerRepositoryPort {
     answerText: string;
     questionId: number | null;
     extraQuestionId: number | null;
+  } | null>;
+
+  findByIdWithContext(answerId: number): Promise<{
+    id: number;
+    sessionId: number;
+    answerText: string;
+    questionId: number | null;
+    extraQuestionId: number | null;
+    category: Category;
+    difficulty: Difficulty;
+    depth: number;
   } | null>;
 }
 

--- a/apps/be/src/modules/question-provider/infra/prisma/extra-question.repository.prisma.ts
+++ b/apps/be/src/modules/question-provider/infra/prisma/extra-question.repository.prisma.ts
@@ -53,6 +53,33 @@ export class ExtraQuestionRepositoryPrisma implements ExtraQuestionRepositoryPor
     };
   }
 
+  /**
+   * 부모 Answer가 가리키는 질문의 depth 조회
+   *
+   * - Normal Question 기반 Answer → depth = 0
+   * - ExtraQuestion 기반 Answer → 해당 ExtraQuestion.depth
+   */
+  async findParentDepthByAnswerId(parentAnswerId: number): Promise<number> {
+    const answer = await this.prisma.userAnswer.findUnique({
+      where: { id: parentAnswerId },
+      include: {
+        extraQuestion: true,
+      },
+    });
+
+    if (!answer) {
+      throw new Error('Parent answer not found');
+    }
+
+    // extraQuestion이 있으면 꼬리질문 기반 Answer
+    if (answer.extraQuestion) {
+      return answer.extraQuestion.depth;
+    }
+
+    // 없으면 Normal Question 기반 Answer
+    return 0;
+  }
+
   async save(data: {
     sessionId: number;
     parentAnswerId: number;

--- a/apps/be/src/modules/question-provider/infra/prisma/user-answer.repository.prisma.ts
+++ b/apps/be/src/modules/question-provider/infra/prisma/user-answer.repository.prisma.ts
@@ -31,4 +31,65 @@ export class UserAnswerRepositoryPrisma implements UserAnswerRepositoryPort {
       },
     });
   }
+
+  async findByIdWithContext(answerId: number) {
+    /**
+     * Answer 단건 조회
+     * - question / extraQuestion을 함께 include하여
+     *   Answer가 어떤 질문 컨텍스트에서 생성되었는지 판단한다.
+     */
+    const answer = await this.prisma.userAnswer.findUnique({
+      where: { id: answerId },
+      include: {
+        question: true,
+        extraQuestion: true,
+      },
+    });
+
+    /**
+     * Answer가 존재하지 않는 경우
+     */
+    if (!answer) return null;
+
+    /**
+     * Answer의 질문 컨텍스트로부터 category / difficulty 추출
+     *
+     * - 일반 Question에 대한 답변인 경우: answer.question 기준
+     * - ExtraQuestion(꼬리질문)에 대한 답변인 경우: answer.extraQuestion 기준
+     *
+     * 두 경우 모두 동일한 Context(category, difficulty)를
+     * 상위 로직에서 일관되게 사용할 수 있도록 여기서 정규화한다.
+     */
+    const category = answer.question?.category ?? answer.extraQuestion?.category;
+
+    const difficulty = answer.question?.difficulty ?? answer.extraQuestion?.difficulty;
+
+    const depth = answer.extraQuestion ? answer.extraQuestion.depth : 0;
+
+    /**
+     * 정상적인 Answer라면 반드시 하나의 질문 컨텍스트를 가져야 한다.
+     * category / difficulty를 추출할 수 없는 경우는
+     * 데이터 정합성이 깨진 상태로 판단하여 예외 처리한다.
+     */
+    if (!category || !difficulty) {
+      throw new Error('ANSWER_CONTEXT_NOT_FOUND');
+    }
+
+    /**
+     * Answer + 해석된 질문 컨텍스트 반환
+     *
+     * - question / extraQuestion raw entity는 노출하지 않고
+     * - 상위 레이어에서는 Context 정보만 사용하도록 제한한다.
+     */
+    return {
+      id: answer.id,
+      sessionId: answer.sessionId,
+      answerText: answer.answerText,
+      questionId: answer.questionId,
+      extraQuestionId: answer.extraQuestionId,
+      category,
+      difficulty,
+      depth,
+    };
+  }
 }

--- a/apps/be/src/users/credits/user-credits.repository.ts
+++ b/apps/be/src/users/credits/user-credits.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '@/infra/database/prisma.service';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class UserCreditsRepository {
@@ -10,6 +11,8 @@ export class UserCreditsRepository {
    * 유저의 현재 총 크레딧 조회 (append-only ledger 구조)
    *
    * 동기화 불일치 문제 차단 위함.
+   * - 모든 credit row의 amount 합계를 Source of Truth로 사용
+   * - 캐싱/컬럼 저장 방식 대비 동기화 불일치 문제를 원천 차단
    */
   async getTotalCredit(userId: number): Promise<number> {
     const result = await this.prisma.userCredit.aggregate({
@@ -36,13 +39,15 @@ export class UserCreditsRepository {
 
   /**
    * 유저 크레딧 차감
-   * 크레딧 차감은 기존 row를 수정하지 않고
-   * 새로운 row를 추가하는 방식으로 처리
+   * - 트랜잭션(TransactionClient) 대응
+   * - 크레딧은 append-only ledger 구조 유지
    *
    * amount는 항상 음수(-)로 저장
    */
-  async consume(userId: number, reason: string, amount: number = 1) {
-    return this.prisma.userCredit.create({
+  async consume(userId: number, reason: string, amount: number = 1, tx?: Prisma.TransactionClient) {
+    const client = tx ?? this.prisma;
+
+    return client.userCredit.create({
       data: {
         userId,
         amount: -amount,


### PR DESCRIPTION
## 🔗 관련 이슈

- close #138

<br/>

## 🔍 작업 내용

세션 생성 및 질문 진행 로직에서  
응답 DTO 기준으로 하드코딩되거나 임시값으로 처리되던 상태 관리 로직을 제거하고,  
DB(Session, UserCredit)를 단일 Source of Truth로 사용하도록 리팩토링했습니다.

### 배경 / 문제점

- 세션 생성 시 `remainedCredit`이 항상 `20`으로 반환되었으나, 실제 저장/차감 로직이 없음
- `getNextQuestion` 응답에서 `currentQuestionCount`가 DB 값과 불일치할 가능성 존재
- 질문 진행에 따른 `depth` 증가 규칙이 명확하지 않음
- 질문 소진 / 크레딧 소진 시 세션 종료 처리 미구현
- 세션 상태가 응답 DTO 기준으로 관리되고 있어 DB 상태와 불일치 발생 가능

---

### 주요 변경 사항

#### 1. 세션 생성 / 질문 진행 시 크레딧 처리 로직 정리
- UserCredit의 `remainedCredit`처리
- 하드코딩된 `remainedCredit: 20` 제거
- 질문 1개당 차감 규칙 정의 및 적용
- 크레딧 차감 로직을 트랜잭션 내에서 처리하도록 개선  
  (크레딧 차감 + 질문 생성 + 세션 카운팅 원자성 보장)
- 크레딧 부족 시 예외 처리 로직 추가  
  *(현재 테스트를 위해 주석 처리 상태)*

#### 2. currentQuestionCount 증가 로직 개선
- 응답 DTO 기준 증가 로직 제거
- DB에 저장된 `session.currentQuestionCount` 기준으로 증가
- 응답에서는 항상 DB에 저장된 값을 그대로 반환하도록 수정
- 중복 증가 이슈 수정

#### 3. depth 카운팅 규칙 명확화
- 질문 진행 흐름에 따른 depth 증가 조건 정의
- 부모 질문 depth 기반으로 다음 질문 depth 계산
- 세션/질문 엔티티에 일관되게 반영

#### 4. 세션 종료 처리 로직 정리
- 질문이 더 이상 없을 경우 세션 종료
- `completedAt` 기록
- 세션 종료 조건 통합
  - 질문 소진
  - 크레딧 소진

---

## 🎯 완료 조건 체크

- [x] 하드코딩된 `remainedCredit` 값 제거
- [x] 세션 응답 값이 항상 DB 상태와 일치하도록 수정
- [x] `currentQuestionCount / depth` 증가 규칙 의도대로 동작 확인
- [x] 크레딧 차감 및 질문 생성 로직 트랜잭션 처리

<br/>

## 💬 리뷰 요구 사항

> 리뷰 예상 시간: `10분`  

- **depth 규칙**
  - 기본 question의 depth는 `0`
  - extra-question은 부모 질문 기준으로 `+1`씩 증가하도록 처리했습니다.
  - 질문 구조상, depth 값이 항상 의미를 갖도록 의도했습니다.

- **currentQuestionCount 규칙**
  - 세션의 `currentQuestionCount`는 `1`부터 시작하도록 설정했습니다.
  - 실제 사용자 기준에서 “첫 번째 질문”을 1로 인식하는 흐름에 맞추기 위함입니다.
  - 증가 로직은 응답 DTO가 아닌 **DB(Session) 값 기준으로만 처리**됩니다.

- **트랜잭션 처리 범위**
  - 질문 생성, 크레딧 차감, 세션 카운팅 증가를 **하나의 트랜잭션으로 묶어 처리**했습니다.
  - 중간 실패 시 데이터 불일치를 방지하는 것을 우선 목표로 했습니다.