### PR TITLE
Feat/#122 jwt 인증 가드 및 전략 구현

### DIFF
--- a/apps/be/main.ts
+++ b/apps/be/main.ts
@@ -22,7 +22,7 @@ async function bootstrap() {
     .setTitle('Talkit API')
     .setDescription('Talkit 백엔드 API 문서')
     .setVersion('1.0')
-    // .addBearerAuth() // JWT 쓰면 추후 설정
+    .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/apps/be/src/auth/auth.module.ts
+++ b/apps/be/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from '@/users/users.module';
 
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
 
 @Module({
@@ -24,7 +25,7 @@ import { LocalStrategy } from './strategies/local.strategy';
       }),
     }),
   ],
-  providers: [AuthService, LocalStrategy],
+  providers: [AuthService, LocalStrategy, JwtStrategy],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -45,7 +45,7 @@ export class AuthService {
   }
 
   async login(user: any) {
-    const payload = { sub: user.id, email: user.email }; // 토큰에 담을 정보
+    const payload = { sub: user.id, nickname: user.nickname, email: user.email }; // 토큰에 담을 정보
 
     // Access Token 생성
     const accessToken = this.jwtService.sign(payload);

--- a/apps/be/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/be/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/apps/be/src/auth/strategies/jwt.strategy.ts
+++ b/apps/be/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+
+import { JwtPayload } from '../types/jwt-payload-type';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(), // 헤더에서 토큰 추출
+      ignoreExpiration: false, // 만료된 토큰 거부
+
+      secretOrKey: configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
+    });
+  }
+
+  // 토큰 검증 성공 시 실행
+  validate(payload: JwtPayload) {
+    return { id: payload.sub, nickname: payload.nickname, email: payload.email };
+  }
+}

--- a/apps/be/src/auth/types/jwt-payload-type.ts
+++ b/apps/be/src/auth/types/jwt-payload-type.ts
@@ -1,0 +1,5 @@
+export type JwtPayload = {
+  sub: number; // userId
+  nickname: string;
+  email?: string;
+};

--- a/apps/be/src/common/decorators/active-user.decorator.ts
+++ b/apps/be/src/common/decorators/active-user.decorator.ts
@@ -1,0 +1,15 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+
+export type ActiveUser = {
+  id: number;
+  nickname: string;
+  email?: string;
+};
+
+// JwtAuthGuard 검증 후 request 객체의 유저 정보를 컨트롤러에서 바로 쓸 수 있도록 꺼내주는 역할의 데코레이터 생성
+export const ActiveUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): ActiveUser => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);


### PR DESCRIPTION
## 🔗 관련 이슈

- close #122 

<br/>

## 🔍 작업 내용

로그인한 사용자만 접근 가능한 API를 보호하기 위해 JWT 검증 로직과 편의 기능을 구현했습니다.

* **`src/auth/strategies/jwt.strategy.ts`**
  * Passport `Strategy` 상속 및 구현
  * Header에서 Bearer Token 추출 및 `JWT_ACCESS_SECRET`을 이용한 서명 검증 로직 추가
  * 검증 성공 시 `payload`에서 `id`, `nickname`, `email`을 추출하여 반환


* **`src/auth/guards/jwt-auth.guard.ts`**
  * `AuthGuard('jwt')`를 상속받아 전역/개별 라우트에서 사용할 수 있는 가드 클래스 생성


* **`src/auth/decorators/active-user.decorator.ts`**
  * 컨트롤러에서 `req.user` 대신 `@ActiveUser()`로 유저 정보를 타입 안전하게 꺼낼 수 있는 커스텀 데코레이터 구현


* **`src/auth/auth.module.ts`**
  * `JwtStrategy`를 Provider로 등록


* **`src/main.ts`**
  * Swagger 문서 상단에 `Authorize` 버튼(Bearer Auth) 활성화 설정 추가

<br/>

## 📷 스크린샷

<img width="669" height="628" alt="image" src="https://github.com/user-attachments/assets/55fe4051-0846-43ea-89dc-35bdeca561cf" />

헤더의 bearer에 토큰 미포함시에 401 에러 발생 확인

<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `3분`
> 리뷰어에게 남기고 싶은 말)

- 이전 작업인 **#120 이슈(PR)**가 `develop` 브랜치에 머지된 이후, 해당 내용을 Rebase 하고 충돌을 해결한 뒤 머지할 예정입니다
  로직 자체는 완성되어 있으니, 인증 전략이나 데코레이터 구현 방식에 대해 미리 의견 주시면 감사하겠습니다!

- JwtPayload에 우선은 userid, nickname, email으로 정해두었는데, email의 경우 추후에 소셜 로그인 구현 시에 email은 null일수도 있기 때문에 nullable하게 설정해두었습니다. 


<br/>

## 📄 추가 전달 사항

