### PR TITLE
Feat/#135 음성 답변 ux 개션

### DIFF
--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -8,6 +8,7 @@ const AnswerSection = () => {
   const [editText, setEditText] = useState('');
 
   const isSttLoading = phase === ANSWER_PHASE.STT_LOADING;
+  const isEditEmpty = isEditing && !editText.trim();
 
   const shouldShow = phase !== ANSWER_PHASE.IDLE && phase !== ANSWER_PHASE.RECORDING;
   if (!shouldShow) return null;
@@ -18,7 +19,7 @@ const AnswerSection = () => {
   };
 
   const handleEditDone = () => {
-    setSttText(editText);
+    setSttText(editText.trim());
     setIsEditing(false);
   };
 
@@ -27,11 +28,12 @@ const AnswerSection = () => {
       <h3 className="sr-only">음성 인식 결과</h3>
       <div className="flex items-center justify-between">
         <p className="text-xl font-bold">나의 답변</p>
-        {sttText && !isSttLoading && (
+        {!isSttLoading && (
           <button
             type="button"
             className="rounded-md border border-gray px-3 py-1 text-sm text-dark-gray hover:bg-gray/20"
             onClick={isEditing ? handleEditDone : handleEditStart}
+            disabled={isEditEmpty}
           >
             {isEditing ? '수정 완료' : '수정'}
           </button>
@@ -43,14 +45,21 @@ const AnswerSection = () => {
             <div className="loader-dots" />
             <p className="text-dark-gray">AI가 음성을 텍스트로 변환하고 있어요</p>
           </div>
-        ) : sttText ? (
+        ) : sttText?.trim() ? (
           isEditing ? (
-            <textarea
-              className="w-full resize-none rounded-md border border-gray p-3 focus:border-primary focus:outline-none"
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              rows={4}
-            />
+            <>
+              <textarea
+                className={`w-full resize-none rounded-md border p-3 focus:outline-none ${
+                  isEditEmpty
+                    ? 'border-red-500 focus:border-red-500'
+                    : 'border-gray focus:border-primary'
+                }`}
+                value={editText}
+                onChange={(e) => setEditText(e.target.value)}
+                rows={4}
+              />
+              {isEditEmpty && <p className="mt-1 text-sm text-red-500">답변을 입력해 주세요</p>}
+            </>
           ) : (
             <p>{sttText}</p>
           )

--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -1,17 +1,42 @@
+import { useState } from 'react';
+
 import { ANSWER_PHASE, useAnswerFlow } from '@/features/learning/lib/contexts/answer-flow-context';
 
 const AnswerSection = () => {
-  const { phase, sttText } = useAnswerFlow();
+  const { phase, sttText, setSttText } = useAnswerFlow();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState('');
 
   const isSttLoading = phase === ANSWER_PHASE.STT_LOADING;
 
   const shouldShow = phase !== ANSWER_PHASE.IDLE && phase !== ANSWER_PHASE.RECORDING;
   if (!shouldShow) return null;
 
+  const handleEditStart = () => {
+    setEditText(sttText ?? '');
+    setIsEditing(true);
+  };
+
+  const handleEditDone = () => {
+    setSttText(editText);
+    setIsEditing(false);
+  };
+
   return (
     <section className="relative overflow-hidden rounded-2xl border border-gray bg-white p-8 shadow-sm after:absolute after:top-0 after:left-0 after:h-full after:w-1 after:bg-primary">
       <h3 className="sr-only">음성 인식 결과</h3>
-      <p className="text-xl font-bold">나의 답변</p>
+      <div className="flex items-center justify-between">
+        <p className="text-xl font-bold">나의 답변</p>
+        {sttText && !isSttLoading && (
+          <button
+            type="button"
+            className="rounded-md border border-gray px-3 py-1 text-sm text-dark-gray hover:bg-gray/20"
+            onClick={isEditing ? handleEditDone : handleEditStart}
+          >
+            {isEditing ? '수정 완료' : '수정'}
+          </button>
+        )}
+      </div>
       <div className="mt-4 rounded-md">
         {isSttLoading ? (
           <div className="flex flex-col items-center gap-3">
@@ -19,7 +44,16 @@ const AnswerSection = () => {
             <p className="text-dark-gray">AI가 음성을 텍스트로 변환하고 있어요</p>
           </div>
         ) : sttText ? (
-          <p>{sttText}</p>
+          isEditing ? (
+            <textarea
+              className="w-full resize-none rounded-md border border-gray p-3 focus:border-primary focus:outline-none"
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              rows={4}
+            />
+          ) : (
+            <p>{sttText}</p>
+          )
         ) : (
           <p>음성이 인식되지 않았어요. 다시 녹음해 주세요</p>
         )}

--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -23,20 +23,35 @@ const AnswerSection = () => {
     setIsEditing(false);
   };
 
+  const handleEditCancel = () => {
+    setIsEditing(false);
+  };
+
   return (
     <section className="relative overflow-hidden rounded-2xl border border-gray bg-white p-8 shadow-sm after:absolute after:top-0 after:left-0 after:h-full after:w-1 after:bg-primary">
       <h3 className="sr-only">음성 인식 결과</h3>
       <div className="flex items-center justify-between">
         <p className="text-xl font-bold">나의 답변</p>
         {!isSttLoading && (
-          <button
-            type="button"
-            className="rounded-md border border-gray px-3 py-1 text-sm text-dark-gray hover:bg-gray/20"
-            onClick={isEditing ? handleEditDone : handleEditStart}
-            disabled={isEditEmpty}
-          >
-            {isEditing ? '수정 완료' : '수정'}
-          </button>
+          <div className="flex gap-2">
+            {isEditing && (
+              <button
+                type="button"
+                className="rounded-md border border-gray px-3 py-1 text-sm text-dark-gray hover:bg-gray/20"
+                onClick={handleEditCancel}
+              >
+                수정 취소
+              </button>
+            )}
+            <button
+              type="button"
+              className="rounded-md border border-gray px-3 py-1 text-sm text-dark-gray hover:bg-gray/20"
+              onClick={isEditing ? handleEditDone : handleEditStart}
+              disabled={isEditEmpty}
+            >
+              {isEditing ? '수정 완료' : '수정'}
+            </button>
+          </div>
         )}
       </div>
       <div className="mt-4 rounded-md">

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/apis/learning-api';
 import useLearningSession from '@/lib/stores/learning-session';
 import { cn } from '@/lib/utils';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import type { FinishSessionResponseDTO } from '@repo/shared/types/learning';
 
 import { ANSWER_PHASE, useAnswerFlow } from '../../lib/contexts/answer-flow-context';
@@ -101,6 +102,11 @@ const FloatingStepBar = () => {
           <ActionBar.Button
             onClick={handleDeepDive}
             disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || isInsufficientAnswer}
+            disabledReason={
+              phase !== ANSWER_PHASE.FEEDBACK_DONE
+                ? '피드백이 완료된 후 이용할 수 있어요'
+                : '답변이 충분하지 않아 딥다이브를 할 수 없어요'
+            }
             className="flex items-center gap-2"
           >
             <Binoculars className="hidden h-4 w-4 sm:block" />
@@ -108,6 +114,7 @@ const FloatingStepBar = () => {
           </ActionBar.Button>
           <ActionBar.PrimaryButton
             disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE}
+            disabledReason="피드백이 완료된 후 이용할 수 있어요"
             onClick={handleNextQuestion}
           >
             다음 질문
@@ -121,6 +128,11 @@ const FloatingStepBar = () => {
           </ActionBar.Button>
           <ActionBar.PrimaryButton
             disabled={phase !== ANSWER_PHASE.STT_DONE || !sttText}
+            disabledReason={
+              !sttText
+                ? '인식된 답변이 없어요. 다시 녹음해 주세요'
+                : '음성 인식이 완료된 후 제출할 수 있어요'
+            }
             onClick={handleSubmitAnswer}
           >
             답변 제출하기
@@ -140,10 +152,20 @@ const FloatingStepBar = () => {
 
 export default FloatingStepBar;
 
-type ActionBarButtonProps = React.ComponentProps<'button'> & { withDivider?: boolean };
+type ActionBarButtonProps = React.ComponentProps<'button'> & {
+  withDivider?: boolean;
+  disabledReason?: string;
+};
 
-const ActionBarButton = ({ children, className, withDivider, ...rest }: ActionBarButtonProps) => {
-  return (
+const ActionBarButton = ({
+  children,
+  className,
+  withDivider,
+  disabledReason,
+  disabled,
+  ...rest
+}: ActionBarButtonProps) => {
+  const button = (
     <button
       className={cn(
         'px-3 py-2 text-xs disabled:cursor-not-allowed sm:px-6 sm:text-sm',
@@ -151,10 +173,35 @@ const ActionBarButton = ({ children, className, withDivider, ...rest }: ActionBa
           'relative after:absolute after:top-1/2 after:-right-1 after:h-1/2 after:w-px after:-translate-y-1/2 after:bg-gray-300',
         className,
       )}
+      disabled={disabled}
       {...rest}
     >
       {children}
     </button>
+  );
+
+  if (!disabled || !disabledReason) return button;
+
+  return (
+    <Tooltip.Provider delayDuration={200}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <span tabIndex={0} className="inline-flex">
+            {button}
+          </span>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            side="top"
+            sideOffset={8}
+            className="rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+          >
+            {disabledReason}
+            <Tooltip.Arrow className="fill-white" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
   );
 };
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #135

<br/>

## 🔍 작업 내용

### `answer-section.tsx`

- 음성 인식 결과(STT) 텍스트를 수정할 수 있는 편집 모드 추가
    - "수정" 버튼 클릭 시 `textarea`로 전환, "수정 완료" 클릭 시 context에 반영
- 빈 답변 입력 방지 처리
    - `editText.trim()`이 비어있으면 "수정 완료" 버튼 비활성화
    - `textarea` 빨간 보더 + "답변을 입력해 주세요" 안내 문구 표시
- API를 통해 오는 공백 문자열만 있는 경우 "음성이 인식되지 않았어요" 대체 문구로 처리
- 편집 모드에서 수정 취소 버튼 추가

### `floating-step-bar.tsx`

- `@radix-ui/react-tooltip` 적용
- `ActionBarButton`에 `disabledReason` prop 추가
    - 비활성화 상태에서 hover 시 Radix Tooltip으로 사유 표시
    - `<span>` wrapper로 disabled button에서도 hover 이벤트 동작
- 각 버튼별 비활성화 사유 메시지 추가
    - 딥다이브: "피드백이 완료된 후 이용할 수 있어요" / "답변이 충분하지 않아 딥다이브를 할 수 없어요"
    - 다음 질문: "피드백이 완료된 후 이용할 수 있어요"
    - 답변 제출하기: "음성 인식이 완료된 후 제출할 수 있어요" / "인식된 답변이 없어요. 다시 녹음해 주세요"

<br/>

## 📷 스크린샷

https://github.com/user-attachments/assets/e90a57ba-3e07-48b2-822c-452bb4538525



<br/>

## ✅ 체크리스트

- [x]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [x]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: `10분`


<br/>

## 📄 추가 전달 사항

- collision detection 내장으로 뷰포트 밖 overflow 방지하기 위해 `@radix-ui/react-tooltip`를 사용했습니다.
- disabled button은 브라우저가 pointer events를 차단하므로, `<span>` wrapper로 감싸 hover 이벤트를 대신 받도록 처리했습니다