### PR TITLE
Feat/#124 리프레시 토큰 재발급 api 구현

### DIFF
--- a/apps/be/main.ts
+++ b/apps/be/main.ts
@@ -22,7 +22,17 @@ async function bootstrap() {
     .setTitle('Talkit API')
     .setDescription('Talkit 백엔드 API 문서')
     .setVersion('1.0')
-    .addBearerAuth()
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'JWT',
+        description: '로그인 후 받은 Access Token을 입력하세요.',
+        in: 'header',
+      },
+      'access-token',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/apps/be/src/auth/auth.controller.ts
+++ b/apps/be/src/auth/auth.controller.ts
@@ -19,12 +19,14 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 
+import { ActiveUser } from '@/common/decorators/active-user.decorator';
 import { ZodValidationPipe } from '@/common/pipes/zod-validation.pipe';
 import { zodSchemaToOpenAPI } from '@/common/utils/zod-to-openapi.util';
 import { type CreateUserDto, CreateUserSchema } from '@/users/schemas/create-user.schema';
 import { UserResponseSchema } from '@/users/schemas/user-response.schema';
 
 import { AuthService } from './auth.service';
+import { JwtRefreshAuthGuard } from './guards/jwt-refresh-auth.guard';
 import { type LoginDto, LoginSchema } from './schemas/login.schema';
 import type { Response } from 'express';
 
@@ -133,5 +135,102 @@ export class AuthController {
     return {
       accessToken,
     };
+  }
+
+  @Post('refresh')
+  @UseGuards(JwtRefreshAuthGuard)
+  @ApiCookieAuth('refresh-token')
+  @ApiOperation({
+    summary: '토큰 재발급 (Refresh)',
+    description: '쿠키의 Refresh Token을 이용해 새로운 토큰을 발급받습니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '재발급 성공 (새 Access Token 반환)',
+    schema: {
+      type: 'object',
+      properties: {
+        accessToken: {
+          type: 'string',
+          description: '새로 발급된 JWT Access Token',
+          example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '유효하지 않거나 만료된 Refresh Token',
+    schema: {
+      example: {
+        code: 'UnauthorizedException',
+        message: 'Unauthorized',
+      },
+    },
+  })
+  async refresh(
+    @ActiveUser() user: ActiveUser & { refreshToken: string },
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const { accessToken, refreshToken } = await this.authService.rotateRefreshToken(
+      user.id,
+      user.refreshToken,
+    );
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+
+    return { accessToken };
+  }
+
+  @Post('logout')
+  @UseGuards(JwtRefreshAuthGuard)
+  @ApiCookieAuth('refresh-token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '로그아웃',
+    description: '서버의 Refresh Token을 삭제하고 클라이언트 쿠키를 만료시킵니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '로그아웃 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          example: '성공적으로 로그아웃 되었습니다.',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '유효하지 않거나 만료된 Refresh Token',
+    schema: {
+      example: {
+        code: 'UnauthorizedException',
+        message: 'Unauthorized',
+      },
+    },
+  })
+  async logout(@ActiveUser() user: ActiveUser, @Res({ passthrough: true }) res: Response) {
+    // DB에서 리프레시 토큰 삭제
+    await this.authService.logout(user.id);
+
+    // 클라이언트 쿠키 삭제
+    res.clearCookie('refreshToken', {
+      path: '/',
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    });
+
+    return { message: '성공적으로 로그아웃 되었습니다.' };
   }
 }

--- a/apps/be/src/auth/auth.controller.ts
+++ b/apps/be/src/auth/auth.controller.ts
@@ -1,9 +1,19 @@
-import { Body, Controller, HttpCode, Post, Request, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Request,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import {
   ApiBadRequestResponse,
   ApiBody,
   ApiConflictResponse,
+  ApiCookieAuth,
   ApiCreatedResponse,
   ApiOperation,
   ApiResponse,
@@ -40,7 +50,7 @@ export class AuthController {
     description: '이미 존재하는 이메일 또는 닉네임',
     schema: {
       example: {
-        statusCode: 409,
+        code: 'ConflictException',
         message: '이미 존재하는 이메일입니다.',
       },
     },
@@ -49,8 +59,14 @@ export class AuthController {
     description: '유효성 검사 실패 (비밀번호 정규식 미준수 등)',
     schema: {
       example: {
-        statusCode: 400,
-        message: '비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.',
+        code: 'BadRequestException',
+        message: '유효성 검사에 실패했습니다.',
+        errors: {
+          password: [
+            'Too small: expected string to have >=8 characters',
+            '비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.',
+          ],
+        },
       },
     },
   })
@@ -75,7 +91,30 @@ export class AuthController {
   @HttpCode(200)
   @ApiOperation({ summary: '로그인', description: 'Access/Refresh Token 발급' })
   @ApiBody({ schema: zodSchemaToOpenAPI(LoginSchema) })
-  @ApiResponse({ status: 200, description: '성공' })
+  @ApiResponse({
+    status: 200,
+    description: '로그인 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        accessToken: {
+          type: 'string',
+          description: 'JWT Access Token',
+          example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+    schema: {
+      example: {
+        code: 'UnauthorizedException',
+        message: '이메일 또는 비밀번호가 일치하지 않습니다.',
+      },
+    },
+  })
   async login(
     @Request() req,
     @Body(new ZodValidationPipe(LoginSchema)) loginDto: LoginDto,
@@ -84,11 +123,11 @@ export class AuthController {
     const { accessToken, refreshToken } = await this.authService.login(req.user);
 
     res.cookie('refreshToken', refreshToken, {
-      httpOnly: true, // JS에서 접근 불가능 (XSS 방어)
-      secure: process.env.NODE_ENV === 'production', // HTTPS에서만 전송 (배포 시 필수)
-      sameSite: 'lax', // CSRF 방어 (Strict는 UX 이슈가 있을 수 있어 보통 Lax 사용)
-      path: '/auth', // 모든 경로에서 유효
-      maxAge: 14 * 24 * 60 * 60 * 1000, // 14일 (밀리초 단위)
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 14 * 24 * 60 * 60 * 1000,
     });
 
     return {

--- a/apps/be/src/auth/auth.module.ts
+++ b/apps/be/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from '@/users/users.module';
 
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
 
@@ -25,7 +26,7 @@ import { LocalStrategy } from './strategies/local.strategy';
       }),
     }),
   ],
-  providers: [AuthService, LocalStrategy, JwtStrategy],
+  providers: [AuthService, LocalStrategy, JwtStrategy, JwtRefreshStrategy],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -45,24 +45,47 @@ export class AuthService {
   }
 
   async login(user: any) {
-    const payload = { sub: user.id, nickname: user.nickname, email: user.email }; // 토큰에 담을 정보
+    const tokens = await this.getTokens(user.id, user.nickname, user.email);
 
-    // Access Token 생성
-    const accessToken = this.jwtService.sign(payload);
+    await this.updateRefreshToken(user.id, tokens.refreshToken);
 
-    // Refresh Token 생성 (별도 시크릿 사용)
-    const refreshToken = this.jwtService.sign(payload, {
-      secret: this.configService.get('JWT_REFRESH_SECRET'),
-      expiresIn: this.configService.get('JWT_REFRESH_EXPIRATION_TIME'),
-    });
+    return tokens;
+  }
+  // 토큰 생성 헬퍼 함수
+  private async getTokens(userId: number, nickname: string, email?: string) {
+    const payload: JwtPayload = {
+      sub: userId,
+      nickname,
+      email,
+    };
 
-    // Refresh Token 해싱 후 DB 저장
-    const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
-    await this.usersRepository.updateRefreshToken(user.id, hashedRefreshToken);
+    const [accessToken, refreshToken] = await Promise.all([
+      this.jwtService.signAsync(payload, {
+        secret: this.configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
+        expiresIn: this.configService.getOrThrow<string>('JWT_ACCESS_EXPIRATION_TIME') as any,
+      }),
+
+      this.jwtService.signAsync(payload, {
+        secret: this.configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
+        expiresIn: this.configService.getOrThrow<string>('JWT_REFRESH_EXPIRATION_TIME') as any,
+      }),
+    ]);
 
     return {
       accessToken,
       refreshToken,
     };
+  }
+
+  // DB 리프레시 토큰 업데이트 헬퍼 함수
+  private async updateRefreshToken(userId: number, refreshToken: string | null) {
+    let hashedRefreshToken: string | null = null;
+
+    // null이 아닐 경우(재발급) 새로운 토큰 해싱하고 업데이트
+    if (refreshToken) {
+      hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
+    }
+
+    await this.usersRepository.updateRefreshToken(userId, hashedRefreshToken);
   }
 }

--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 
@@ -6,6 +6,7 @@ import { type CreateUserDto } from '@/users/schemas/create-user.schema';
 import { UsersRepository } from '@/users/users.repository';
 import { UsersService } from '@/users/users.service';
 
+import { JwtPayload } from './types/jwt-payload-type';
 import bcrypt from 'bcrypt';
 
 @Injectable()
@@ -51,6 +52,35 @@ export class AuthService {
 
     return tokens;
   }
+
+  async rotateRefreshToken(userId: number, oldRefreshToken: string) {
+    const user = await this.usersRepository.findById(userId);
+
+    // 유저가 없거나, DB에 저장된 토큰이 없는 경우 (로그아웃 된 상태)
+    if (!user || !user.currentRefreshToken) {
+      throw new UnauthorizedException('Access Denied');
+    }
+
+    // 사용자가 보낸 토큰과 DB의 해시값 비교
+    const isRefreshTokenMatching = await bcrypt.compare(oldRefreshToken, user.currentRefreshToken);
+
+    if (!isRefreshTokenMatching) {
+      throw new UnauthorizedException('Invalid Refresh Token');
+    }
+
+    // 새로운 토큰 쌍 발급
+    const tokens = await this.getTokens(userId, user.nickname, user.email || '');
+
+    await this.updateRefreshToken(userId, tokens.refreshToken);
+
+    return tokens;
+  }
+
+  // 로그아웃
+  async logout(userId: number) {
+    await this.usersRepository.updateRefreshToken(userId, null);
+  }
+
   // 토큰 생성 헬퍼 함수
   private async getTokens(userId: number, nickname: string, email?: string) {
     const payload: JwtPayload = {

--- a/apps/be/src/auth/guards/jwt-refresh-auth.guard.ts
+++ b/apps/be/src/auth/guards/jwt-refresh-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtRefreshAuthGuard extends AuthGuard('jwt-refresh') {}

--- a/apps/be/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/apps/be/src/auth/strategies/jwt-refresh.strategy.ts
@@ -1,0 +1,46 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+
+import { JwtPayload } from '../types/jwt-payload-type';
+import { Request } from 'express';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
+  constructor(configService: ConfigService) {
+    super({
+      // 쿠키에서 토큰 추출하는 커스텀 로직
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request: Request) => {
+          return request?.cookies?.refreshToken;
+        },
+      ]),
+
+      // 만료되었는지 확인
+      ignoreExpiration: false,
+
+      // 리프레시 토큰 전용 시크릿 키 사용
+      secretOrKey: configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
+
+      // validate 메서드에서 request 객체를 쓰기 위해 true로 설정
+      passReqToCallback: true,
+    });
+  }
+
+  // 검증 성공 시 실행
+  validate(req: Request, payload: JwtPayload) {
+    const refreshToken = req.cookies?.refreshToken;
+
+    if (!refreshToken) {
+      throw new UnauthorizedException('Refresh token not found');
+    }
+
+    return {
+      id: payload.sub,
+      nickname: payload.nickname,
+      email: payload.email,
+      refreshToken,
+    };
+  }
+}

--- a/apps/be/src/users/users.repository.ts
+++ b/apps/be/src/users/users.repository.ts
@@ -7,6 +7,10 @@ import { Prisma, User } from '@prisma/client';
 export class UsersRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async findById(id: number) {
+    return this.prisma.user.findUnique({ where: { id } });
+  }
+
   // 이메일로 유저 찾기
   async findByEmail(email: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { email } });


### PR DESCRIPTION
## 🔗 관련 이슈

- close #124 
- close #127 

<br/>

## 🔍 작업 내용

Refresh Token Rotation(RTR) 시스템과 로그아웃 기능을 구현했습니다.
### 1. 전략 및 가드 구현 (Security Layer)
- `src/auth/strategies/jwt-refresh.strategy.ts`
  - Cookie에서 refreshToken을 추출하는 로직 구현 (`ExtractJwt.fromExtractors`)
  - DB 해시 대조를 위해 `passReqToCallback: true` 설정 및 validate에서 원본 토큰 반환
- `src/auth/guards/jwt-refresh-auth.guard.ts`
  - 재발급 및 로그아웃 라우트 보호를 위한 가드 추가
### 2. 비즈니스 로직 구현 (Service Layer)
- `src/auth/auth.service.ts`
  - RTR(Refresh Token Rotation) 적용: `rotateRefreshToken` 메서드에서 DB 해시값 비교 후 `Access/Refresh` 토큰 동시 교체
  - 로그아웃 구현: logout 메서드에서 DB의 `currentRefreshToken`을 null로 초기화
  - 리팩토링: 토큰 생성(getTokens) 및 DB 업데이트(updateRefreshToken) 로직을 내부 헬퍼 함수로 분리하여 재사용성 증대
  - 리팩토링: 토큰 생성 시 동기적으로 동작하는 `sign` 대신 `signAsync`를 사용하여 비동기적으로 동작하게 하여 토큰을 암호화하는 동안 Node.js의 메인스레드가 멈추지 않도록 처리 (Non-blocking I/O)

### 3. 컨트롤러
- `src/auth/auth.controller.ts`
  - `POST /auth/refresh`: 쿠키의 리프레시 토큰으로 재발급 요청 처리 및 새 쿠키 설정
  - `POST /auth/logout`: DB 토큰 파기 및 클라이언트 쿠키 만료 처리 (maxAge: 0)

<br/>

## 📷 스크린샷

ui 변경사항이 있다면 추가 + 테스트 커버리지도 좋음!

<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `15분`
> 리뷰어에게 남기고 싶은 말) 

- 기존에 토큰 발급 시에 sign 같은 동기 함수를 사용했는데, 이에 대해 성능 문제가 발생할 것이라 보고 비동기 함수를 사용하는것으로 수정했습니다! 혹시 이 외에 제가 놓친 같은 이슈가 생길 것 같은 코드가 있다면 말씀해주셔도 좋을 것 같아요.

- 로그아웃 기능이 너무 단순해서 해당 PR에서 포함시켰습니다.
- 마찬가지로 이전 PR들 머지되면 rebase 하고 머지할 계획입니다. 이전 PR 커밋 기록들은 빼고 확인해주시면 될 것 같습니다

<br/>

## 📄 추가 전달 사항
