### PR TITLE
Fix/#134 딥다이브 전환 시 타이머 초기화 미동작 이슈 해결

### DIFF
--- a/apps/fe/src/features/learning/components/question/pulsing-mic-button.tsx
+++ b/apps/fe/src/features/learning/components/question/pulsing-mic-button.tsx
@@ -1,13 +1,16 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+
 import useAudioLevel from '../../lib/hooks/use-audio-level';
 import { Mic, MicOff } from 'lucide-react';
 
 type PulsingMicButtonProps = {
   isRecording: boolean;
+  disabled?: boolean;
   stream: MediaStream | null;
   onToggle: () => void;
 };
 
-const PulsingMicButton = ({ isRecording, stream, onToggle }: PulsingMicButtonProps) => {
+const PulsingMicButton = ({ isRecording, disabled, stream, onToggle }: PulsingMicButtonProps) => {
   const audioLevel = useAudioLevel(stream);
 
   // 음량에 따른 버튼 크기 (1.0 ~ 1.5 범위로 증가)
@@ -18,24 +21,41 @@ const PulsingMicButton = ({ isRecording, stream, onToggle }: PulsingMicButtonPro
 
   return (
     <div className="relative flex h-40 w-40 items-center justify-center">
-      <button
-        onClick={onToggle}
-        style={{
-          transform: `scale(${buttonScale})`,
-          boxShadow: isRecording
-            ? `0 0 ${shadowSize}px  rgba(0, 0, 0, 0.1)`
-            : '0 4px 6px rgba(0, 0, 0, 0.1)',
-        }}
-        className={`flex h-24 w-24 items-center justify-center rounded-full transition-all duration-75 ease-out ${
-          isRecording ? 'bg-primary hover:bg-primary/70' : 'bg-gray-700 hover:bg-gray-600'
-        }`}
-      >
-        {isRecording ? (
-          <MicOff className="h-10 w-10 text-white" />
-        ) : (
-          <Mic className="h-10 w-10 text-gray-300" />
-        )}
-      </button>
+      <Tooltip.Provider delayDuration={100}>
+        <Tooltip.Root open={disabled ? undefined : false}>
+          <Tooltip.Trigger asChild>
+            <button
+              onClick={onToggle}
+              disabled={disabled}
+              style={{
+                transform: `scale(${buttonScale})`,
+                boxShadow: isRecording
+                  ? `0 0 ${shadowSize}px  rgba(0, 0, 0, 0.1)`
+                  : '0 4px 6px rgba(0, 0, 0, 0.1)',
+              }}
+              className={`flex h-24 w-24 items-center justify-center rounded-full transition-all duration-75 ease-out disabled:cursor-not-allowed disabled:bg-gray-400 ${
+                isRecording ? 'bg-primary hover:bg-primary/70' : 'bg-gray-700 hover:bg-gray-600'
+              }`}
+            >
+              {isRecording ? (
+                <MicOff className="h-10 w-10 text-white" />
+              ) : (
+                <Mic className="h-10 w-10 text-gray-300" />
+              )}
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              className="data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 z-10000 rounded-xl bg-black/90 px-4 py-2 text-xs font-bold text-white shadow-xl backdrop-blur-sm select-none"
+              side="bottom"
+              sideOffset={15}
+            >
+              음성을 변환하고 있어요
+              <Tooltip.Arrow className="fill-black/90" width={12} height={6} />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>
     </div>
   );
 };

--- a/apps/fe/src/features/learning/components/question/voice-recorder-section.tsx
+++ b/apps/fe/src/features/learning/components/question/voice-recorder-section.tsx
@@ -39,7 +39,12 @@ const VoiceRecorderSection = ({ onRecordingComplete }: VoiceRecorderSectionProps
   return (
     <section className="flex flex-col items-center gap-6">
       <h3 className="sr-only">음성 답변</h3>
-      <PulsingMicButton isRecording={isRecording} stream={stream} onToggle={handleToggle} />
+      <PulsingMicButton
+        isRecording={isRecording}
+        disabled={phase === ANSWER_PHASE.STT_LOADING}
+        stream={stream}
+        onToggle={handleToggle}
+      />
       <p className="text-lg sm:text-2xl">
         <span className="text-dark-gray">남은 시간: </span>
         {formattedTime}

--- a/apps/fe/src/routes/learning/question.tsx
+++ b/apps/fe/src/routes/learning/question.tsx
@@ -71,18 +71,22 @@ const QuestionPageContent = () => {
     return null;
   }
 
+  const sessionKey = question.questionId
+    ? `question-${question.questionId}`
+    : `extra-question-${question.extraQuestionId}`;
+
   return (
     <div className="relative mx-auto flex min-h-screen max-w-250 flex-col gap-8 p-6 sm:p-10">
       <QuestionHeader />
-      <QuestionContent key={`question-content-${question?.questionId}`} />
+      <QuestionContent key={`question-content-${sessionKey}`} />
       <VoiceRecorderSection
-        key={`voice-recorder-section-${question?.questionId}`}
+        key={`voice-recorder-section-${sessionKey}`}
         onRecordingComplete={handleRecordingComplete}
       />
       <AnswerSection />
       <FeedbackSection />
       <div className="flex-1" />
-      <FloatingStepBar key={`floating-step-bar-${question?.questionId}`} />
+      <FloatingStepBar key={`floating-step-bar-${sessionKey}`} />
     </div>
   );
 };


### PR DESCRIPTION
## 🔗 관련 이슈

- close #134

<br/>

## 🔍 작업 내용

### 1. 딥다이브 전환 시 컴포넌트 리마운트 미동작 이슈 해결

- question.tsx — `questionId`와 `extraQuestionId`를 모두 반영하는 `sessionKey` 변수를 도입하여, 딥다이브 연속 전환 시에도 `QuestionContent`, `VoiceRecorderSection`, `FloatingStepBar` 컴포넌트가 올바르게 리마운트되도록 수정
- 접두어(`question-` / `extra-question-`)를 붙여 두 ID 값이 동일한 경우에도 key 충돌이 발생하지 않도록 처리

### 2. STT 변환 중 마이크 버튼 비활성화 및 툴팁 추가

- voice-recorder-section.tsx — `phase === ANSWER_PHASE.STT_LOADING`일 때 `disabled` prop 전달
- pulsing-mic-button.tsx — `disabled` prop 추가, Tailwind `disabled:` modifier로 비활성화 스타일 적용, Radix UI Tooltip으로 비활성화 시 "음성을 변환하고 있어요" 메시지 표시

<br/>

## 📷 스크린샷

https://github.com/user-attachments/assets/6c43baf6-33d6-4c1f-b11e-d3e0c0db14ad


<br/>

## ✅ 체크리스트

- [x]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [x]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: `10분`


<br/>

## 📄 추가 전달 사항

- 질문 전환 시 초기화가 안되는 이슈를 [key prop을 활용한 해결 과정](https://www.notion.so/key-prop-2f6d2bdba92980c68a1bddb43c0b5771)은 노션에 작성해두었습니다!