### PR TITLE
Refactor/#148 세션 및 꼬리질문 에러 처리 구조 개선

### DIFF
--- a/apps/be/src/learning/sessions/services/deep-dive.service.ts
+++ b/apps/be/src/learning/sessions/services/deep-dive.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { CreateExtraQuestionUseCase } from '@/modules/question-provider/application/create-extra-question.usecase';
 import { USER_ANSWER_REPOSITORY } from '@/modules/question-provider/infra/ports/user-answer.repository.port';
@@ -27,11 +27,17 @@ export class DeepDiveService {
 
     const session = await this.sessionsRepository.findById(sessionId);
     if (!session || session.userId !== userId) {
-      throw new BadRequestException('INVALID_SESSION');
+      throw new NotFoundException({
+        code: 'SESSION_NOT_FOUND',
+        message: '세션을 찾을 수 없습니다.',
+      });
     }
 
     if (session.completedAt) {
-      throw new BadRequestException('SESSION_COMPLETED');
+      throw new ConflictException({
+        code: 'SESSION_COMPLETED',
+        message: '이미 완료된 세션입니다.',
+      });
     }
 
     // 크레딧 확인
@@ -39,7 +45,10 @@ export class DeepDiveService {
 
     const answer = await this.answerRepository.findByIdWithContext(answerId);
     if (!answer || answer.sessionId !== sessionId) {
-      throw new BadRequestException('ANSWER_NOT_FOUND');
+      throw new NotFoundException({
+        code: 'ANSWER_NOT_FOUND',
+        message: '답변을 찾을 수 없습니다.',
+      });
     }
 
     // DeepDive 질문 생성

--- a/apps/be/src/learning/sessions/services/sessions-record.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions-record.service.ts
@@ -82,7 +82,21 @@ export class SessionsRecordService {
         sttText: normalizeResult.draftText,
       };
     } catch (error) {
-      this.logger.error('ERROR in record process', error);
+      if (error instanceof NotFoundException) {
+        // 의도된 도메인 에러 → warn
+        this.logger.warn('Domain error in record process', {
+          sessionId,
+          code: (error.getResponse() as any)?.code,
+        });
+        throw error;
+      }
+
+      // 진짜 장애
+      this.logger.error('Unexpected error in record process', {
+        sessionId,
+        error: error instanceof Error ? error.stack : error,
+      });
+
       throw error;
     } finally {
       if (objectKey) {

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 
 import { Difficulty, Domain } from '@/common/enums/learning.enum';
 import { PrismaService } from '@/infra/database/prisma.service';
@@ -62,7 +67,10 @@ export class SessionsService {
     const question = await this.questionService.pickOne(dto.category, dto.difficulty);
 
     if (!question) {
-      throw new BadRequestException('선택한 주제와 난이도에 해당하는 질문이 존재하지 않습니다.');
+      throw new NotFoundException({
+        code: 'QUESTION_NOT_FOUND',
+        message: '선택한 주제와 난이도에 해당하는 질문이 없습니다.',
+      });
     }
 
     /**
@@ -123,7 +131,10 @@ export class SessionsService {
     const session = await this.sessionsRepository.findById(sessionId);
 
     if (!session) {
-      throw new NotFoundException('학습 세션을 찾을 수 없습니다.');
+      throw new NotFoundException({
+        code: 'SESSION_NOT_FOUND',
+        message: '세션을 찾을 수 없습니다.',
+      });
     }
 
     /**
@@ -131,7 +142,10 @@ export class SessionsService {
      */
 
     if (session.completedAt) {
-      throw new BadRequestException('이미 종료된 학습 세션입니다.');
+      throw new ConflictException({
+        code: 'SESSION_COMPLETED',
+        message: '이미 종료된 학습 세션입니다.',
+      });
     }
 
     /**
@@ -150,7 +164,7 @@ export class SessionsService {
        */
 
       await this.finishSession(sessionId);
-      throw new BadRequestException({
+      throw new ConflictException({
         code: 'SESSION_COMPLETED',
         message: '더 이상 제공할 질문이 없어 세션이 종료되었습니다.',
       });

--- a/apps/be/src/modules/question-provider/application/question-context-resolver.ts
+++ b/apps/be/src/modules/question-provider/application/question-context-resolver.ts
@@ -1,4 +1,9 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 
 import { Category, Difficulty } from '@prisma/client';
 
@@ -44,7 +49,10 @@ export class QuestionContextResolver {
     const answer = await this.answerRepository.findById(answerId);
 
     if (!answer) {
-      throw new Error(`ANSWER_NOT_FOUND: answerId=${answerId}`);
+      throw new NotFoundException({
+        code: 'ANSWER_NOT_FOUND',
+        message: `Answer not found. answerId=${answerId}`,
+      });
     }
 
     /**
@@ -54,7 +62,10 @@ export class QuestionContextResolver {
       const question = await this.questionRepository.findById(answer.questionId);
 
       if (!question) {
-        throw new Error(`QUESTION_NOT_FOUND: questionId=${answer.questionId}`);
+        throw new NotFoundException({
+          code: 'QUESTION_NOT_FOUND',
+          message: `Question not found. questionId=${answer.questionId}`,
+        });
       }
 
       return {
@@ -72,7 +83,10 @@ export class QuestionContextResolver {
       const extraQuestion = await this.extraQuestionRepository.findById(answer.extraQuestionId);
 
       if (!extraQuestion) {
-        throw new Error(`EXTRA_QUESTION_NOT_FOUND: extraQuestionId=${answer.extraQuestionId}`);
+        throw new NotFoundException({
+          code: 'EXTRA_QUESTION_NOT_FOUND',
+          message: `Extra question not found. extraQuestionId=${answer.extraQuestionId}`,
+        });
       }
 
       return {
@@ -87,6 +101,9 @@ export class QuestionContextResolver {
      * 데이터 무결성 오류
      * (questionId, extraQuestionId 둘 다 null)
      */
-    throw new Error(`Invalid answer relation. answerId=${answerId} has no question reference.`);
+    throw new InternalServerErrorException({
+      code: 'INVALID_ANSWER_RELATION',
+      message: `Invalid answer relation. answerId=${answerId} has no question reference.`,
+    });
   }
 }

--- a/apps/be/src/modules/question-provider/application/question-context-resolver.ts
+++ b/apps/be/src/modules/question-provider/application/question-context-resolver.ts
@@ -44,7 +44,7 @@ export class QuestionContextResolver {
     const answer = await this.answerRepository.findById(answerId);
 
     if (!answer) {
-      throw new NotFoundException(`Answer not found. answerId=${answerId}`);
+      throw new Error(`ANSWER_NOT_FOUND: answerId=${answerId}`);
     }
 
     /**
@@ -54,7 +54,7 @@ export class QuestionContextResolver {
       const question = await this.questionRepository.findById(answer.questionId);
 
       if (!question) {
-        throw new NotFoundException(`Question not found. questionId=${answer.questionId}`);
+        throw new Error(`QUESTION_NOT_FOUND: questionId=${answer.questionId}`);
       }
 
       return {
@@ -72,9 +72,7 @@ export class QuestionContextResolver {
       const extraQuestion = await this.extraQuestionRepository.findById(answer.extraQuestionId);
 
       if (!extraQuestion) {
-        throw new NotFoundException(
-          `ExtraQuestion not found. extraQuestionId=${answer.extraQuestionId}`,
-        );
+        throw new Error(`EXTRA_QUESTION_NOT_FOUND: extraQuestionId=${answer.extraQuestionId}`);
       }
 
       return {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #148

<br/>

## 🔍 작업 내용

기존 에러 중에 code만 반환하거나, message만 반환하고 있는 경우들이 있어 해당 부분 수정하였고,
서로 다른 의미의 에러가 `BadRequestException`으로 일괄 처리되던 부분을 개선하여,
에러의 성격에 맞는 처리 방식으로 분리했습니다.

### 1. 세션(Session) 관련 에러 처리 개선
- 세션 상태 검증 로직에서 BadRequestException을 상태 의미에 맞는 예외로 정리
- HTTP 의미를 가지는 예외는 Service 레이어까지만 사용하도록 정리

### 2. 꼬리질문(ExtraQuestion) 생성 흐름 에러 처리 정리
- 꼬리질문 생성 UseCase에서 HTTP 예외 사용 제거
- 외부 시스템(LLM) 실패 및 데이터 무결성 오류는 그대로 상위로 전파

### 3. 도메인 내부 컴포넌트 에러 처리 기준 정리
- QuestionContextResolver 등 도메인 내부 Helper에서 HttpException 제거
- 데이터 무결성 오류 및 전제 조건 위반은 일반 Error로 처리
- HTTP 레이어에서만 HTTP 상태 코드 의미를 가지도록 책임 분리

<br/>

## 📷 스크린샷

- UI 변경 사항 없음
- 에러 처리 구조 개선 작업으로 화면 변경은 발생하지 않음

<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 세션 및 꼬리질문 관련 에러 처리 및 예외 상황을 검토했습니다.
- [x] HTTP 레이어와 도메인 레이어 간 에러 책임이 분리되었는지 확인했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

> 리뷰 예상 시간: `10분`  
