### PR TITLE
Feat/#123 인증 상태 관리 및 axios 설정 구현

### DIFF
--- a/apps/fe/src/apis/http.ts
+++ b/apps/fe/src/apis/http.ts
@@ -1,4 +1,5 @@
 import { ENV } from '@/constants/env';
+import { useAuthStore } from '@/lib/stores/user-auth-store';
 
 import axios, { type AxiosInstance } from 'axios';
 
@@ -8,10 +9,34 @@ const axiosInstance: AxiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 });
 
-// TODO: [요청 인터셉터] 토큰 주입 등 공통 로직
+axiosInstance.interceptors.request.use(
+  (config) => {
+    // Auth Store에서 토큰만 가져옴
+    const accessToken = useAuthStore.getState().accessToken;
+
+    if (accessToken && config.headers) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 
 // TODO: [응답 인터셉터] 에러 공통 처리
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    // TODO: 401 Unauthorized 에러 발생 시 토큰 재발급(Silent Refresh) 로직
+    // 백엔드의 GET /auth/refresh 엔드포인트를 호출 (Task 3-3-4)
 
+    return Promise.reject(error);
+  },
+);
 export default axiosInstance;

--- a/apps/fe/src/lib/stores/user-auth-store.ts
+++ b/apps/fe/src/lib/stores/user-auth-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+type AuthState = {
+  // State
+  accessToken: string | null;
+  isAuthenticated: boolean;
+
+  // Actions
+  setAccessToken: (token: string | null) => void;
+  clearAuth: () => void; // 로그아웃 시 호출
+};
+
+export const useAuthStore = create<AuthState>()(
+  devtools(
+    (set) => ({
+      accessToken: null,
+      isAuthenticated: false,
+
+      setAccessToken: (token) =>
+        set({ accessToken: token, isAuthenticated: !!token }, false, 'auth/setAccessToken'),
+
+      clearAuth: () => set({ accessToken: null, isAuthenticated: false }, false, 'auth/clearAuth'),
+    }),
+    { name: 'AuthStore' },
+  ),
+);

--- a/apps/fe/src/lib/stores/user-store.ts
+++ b/apps/fe/src/lib/stores/user-store.ts
@@ -1,54 +1,31 @@
 import type { UserInfoResponseDto } from '@repo/shared/types/user';
 
 import { create } from 'zustand';
-
-const mockUserData: UserInfoResponseDto = {
-  profile: {
-    nickname: '코딩하는토끼',
-    profileImage: 'https://s3.ap-northeast-2.amazonaws.com/talkit/profiles/user_123.png',
-    bio: '안녕하세요, 백엔드 마스터를 꿈꾸는 개발자입니다.',
-  },
-  progression: {
-    level: 12,
-    currentXp: 450,
-    requiredXpForNextLevel: 1200,
-    lp: 1422,
-  },
-  studyStats: {
-    solvedProblemCount: 128,
-    streak: 5,
-    totalStudyTime: 360,
-  },
-  social: {
-    followerCount: 42,
-    followCount: 15,
-  },
-  remainingCredit: 9,
-};
-
-// todo: 추후 mock 데이터 제거 후 아래 null로 초기 상태값 세팅하도록 변경하면 됩니다.
-// const initialUserData: UserInfoResponseDto = {
-//   profile: null,
-//   progression: null,
-//   studyStats: null,
-//   social: null,
-//   remainingCredit: null,
-// };
+import { devtools } from 'zustand/middleware';
 
 type UserState = {
-  userInfo: UserInfoResponseDto;
+  userInfo: UserInfoResponseDto | null;
   setUserInfo: (info: UserInfoResponseDto) => void;
+  clearUserInfo: () => void;
   updateCredit: (amount: number) => void;
 };
 
 // 사용자 정보 상태 전역 상태 store
-export const useUserStore = create<UserState>((set) => ({
-  userInfo: mockUserData,
-
-  setUserInfo: (info) => set({ userInfo: info }),
-
-  updateCredit: (amount) =>
-    set((state) => ({
-      userInfo: { ...state.userInfo, remainingCredit: amount },
-    })),
-}));
+export const useUserStore = create<UserState>()(
+  devtools(
+    (set) => ({
+      userInfo: null,
+      setUserInfo: (userInfo) => set({ userInfo }, false, 'userInfo/setUserInfo'),
+      clearUserInfo: () => set({ userInfo: null }, false, 'userInfo/clearUserInfo'),
+      updateCredit: (amount) =>
+        set(
+          (state) => ({
+            userInfo: state.userInfo ? { ...state.userInfo, remainingCredit: amount } : null,
+          }),
+          false,
+          'user/updateCredit',
+        ),
+    }),
+    { name: 'UserStore' },
+  ),
+);

--- a/apps/fe/src/routes/learning/index.tsx
+++ b/apps/fe/src/routes/learning/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { startSessionApi } from '@/apis/learning-api';
 import { QUESTION_CATEGORY_CONFIG, QUESTION_DIFFICULTY_CONFIG } from '@/constants/question';
@@ -16,6 +16,16 @@ const LearningPage = () => {
   const navigate = useNavigate();
 
   const setQuestion = useLearningSession((state) => state.setQuestion);
+
+  useEffect(() => {
+    if (!userInfo) {
+      navigate({ to: '/', replace: true });
+    }
+  }, [userInfo, navigate]);
+
+  if (!userInfo) {
+    return null; // todo: 혹은 <div className="...">로그인 페이지로 이동 중...</div>
+  }
 
   const { profile, progression, studyStats } = userInfo;
 

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -29,3 +29,15 @@ export type UserInfoResponseDto = {
   social: Social;
   remainingCredit: number;
 };
+
+export type AuthResponseDto = {
+  accessToken: string;
+};
+
+export type RegisterResponseDto = {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #123 

<br/>

## 🔍 작업 내용

- 인증 상태(액세스 토큰, 인증여부)를 관리하는 store를 추가 (`/src/lib/store/user-auth-store.ts`)
- 기존 user-store코드 리팩토링 (`/src/lib/store/user-store.ts`)
  - mock 데이터 기반 코드를 제거하고 초기 userinfo를 null로 설정
  - zustand의 `devtools` 미들웨어를 도입하여 상태의 변화 디버깅이 용이하게 수정
  - clearUserInfo() 메서드 추가
- auth(로그인, 리프레시), 회원가입 응답 dto 타입 추가 (`shared/types/user.ts`)
- axios 인스턴스 설정에서 `withCredentials: true`로 수정하여 서버와 Refresh Token 쿠키 교환이 가능하도록 적용
- axios interceptor의 구조를 잡았습니다. 
  - Request Interceptor: 헤더에 액세스 토큰을 주입하는 인터셉터
  - Response Interceptor: 401 에러 발생 시(액세스 토큰 만료 등) 리프레시 토큰을 통해 재발급 요청을 보내는 로직이 추가되어야 한다는 주석 추가 (구조만 잡았습니다)

<br/>

## 📷 스크린샷


<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `3분`
> 리뷰어에게 남기고 싶은 말)

추후에 응답 인터셉터에서 에러 핸들링 로직도 추가하는걸 고려중입니다.
<br/>

## 📄 추가 전달 사항
문제 해결과정은 wiki에 작성!! 토의를 하고 싶다면 discussion으로!

- 공유한 내용이나 반영된 내용은 wiki에 이어서 작성(사고나 작업의 변화를 보기 위해 기존의 내용 수정X)
