### PR TITLE
Feat/#119 회원가입 api 연동 및 예외 처리

### DIFF
--- a/apps/be/src/auth/auth.controller.ts
+++ b/apps/be/src/auth/auth.controller.ts
@@ -30,7 +30,7 @@ import { JwtRefreshAuthGuard } from './guards/jwt-refresh-auth.guard';
 import { type LoginDto, LoginSchema } from './schemas/login.schema';
 import type { Response } from 'express';
 
-@Controller('auth')
+@Controller('/api/auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 

--- a/apps/be/src/users/users.controller.ts
+++ b/apps/be/src/users/users.controller.ts
@@ -10,7 +10,7 @@ import {
 import { UsersService } from './users.service';
 
 @ApiTags('User')
-@Controller('users')
+@Controller('/api/users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 

--- a/apps/fe/src/apis/auth-api.ts
+++ b/apps/fe/src/apis/auth-api.ts
@@ -1,0 +1,38 @@
+import type { CreateUserDto } from '@/features/auth/schemas/register-schema';
+
+import axiosInstance from './http';
+
+export type CheckDuplicateResponse = {
+  isDuplicate: boolean;
+};
+
+// 이메일 중복 확인
+export const checkEmailDuplicate = async (email: string) => {
+  const { data } = await axiosInstance.get<CheckDuplicateResponse>('/users/check-duplicate', {
+    params: {
+      type: 'email',
+      value: email,
+    },
+  });
+  return data;
+};
+
+// 닉네임 중복 확인
+export const checkNicknameDuplicate = async (nickname: string) => {
+  const { data } = await axiosInstance.get<CheckDuplicateResponse>('/users/check-duplicate', {
+    params: {
+      type: 'nickname',
+      value: nickname,
+    },
+  });
+  return data;
+};
+
+// 회원가입
+export const registerUser = async (data: CreateUserDto) => {
+  // 프론트에서만 사용되는 입력 빼고 payload로 추출
+  const { confirmPassword, termsAgreed, ...payload } = data;
+
+  const { data: responseData } = await axiosInstance.post<void>('/auth/register', payload);
+  return responseData;
+};

--- a/apps/fe/src/routes/_public/register.tsx
+++ b/apps/fe/src/routes/_public/register.tsx
@@ -1,16 +1,20 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { checkEmailDuplicate, checkNicknameDuplicate, registerUser } from '@/apis/auth-api';
 import { AuthHeader } from '@/features/auth/components/AuthHeader';
 import { AuthLayout } from '@/features/auth/components/AuthLayout';
 import { FormInput } from '@/features/auth/components/FormInput';
 import { type CreateUserDto, CreateUserSchema } from '@/features/auth/schemas/register-schema';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { type BackendErrorResponse } from '@repo/shared/types/error';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
-import { Check } from 'lucide-react';
+import { isAxiosError } from 'axios';
+import { Check, Loader2 } from 'lucide-react';
 
 const RegisterPage = () => {
+  const navigate = useNavigate();
   const [emailChecked, setEmailChecked] = useState(false);
 
   const {
@@ -36,19 +40,21 @@ const RegisterPage = () => {
       const isSyntaxValid = await trigger('nickname');
 
       if (isSyntaxValid) {
-        // todo: 닉네임 중복검사 api 요청
-        console.log('[API 요청] 닉네임 중복 검사:', nicknameValue);
+        try {
+          const { isDuplicate } = await checkNicknameDuplicate(nicknameValue);
 
-        // API 호출 시뮬레이션 (실제 api 연동 후 제거)
-        const isDuplicate = nicknameValue === '중복된닉네임'; // 테스트용
-
-        if (isDuplicate) {
-          setError('nickname', {
-            type: 'manual',
-            message: '이미 사용 중인 닉네임입니다.',
-          });
-        } else {
-          clearErrors('nickname');
+          if (isDuplicate) {
+            setError('nickname', {
+              type: 'manual',
+              message: '이미 사용 중인 닉네임입니다.',
+            });
+          } else {
+            clearErrors('nickname');
+          }
+        } catch (error) {
+          // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
+          console.error('닉네임 중복 확인 시스템 에러', error);
+          alert('닉네임 확인 중 오류가 발생했습니다.');
         }
       }
     }, 1000);
@@ -64,19 +70,22 @@ const RegisterPage = () => {
     const isValidFormat = await trigger('email');
     if (!isValidFormat) return;
 
-    // Todo: 실제 중복 검사 API 요청 구현
-    // API 결과 시뮬레이션
-    const isDuplicate = emailValue === 'duplicate@test.com'; // 테스트용
-
-    if (isDuplicate) {
-      setError('email', {
-        type: 'manual',
-        message: '이미 사용 중인 이메일입니다.',
-      });
-      setEmailChecked(false);
-    } else {
-      clearErrors('email');
-      setEmailChecked(true);
+    try {
+      const { isDuplicate } = await checkEmailDuplicate(emailValue);
+      if (isDuplicate) {
+        setError('email', {
+          type: 'manual',
+          message: '이미 사용 중인 이메일입니다.',
+        });
+        setEmailChecked(false);
+      } else {
+        clearErrors('email');
+        setEmailChecked(true);
+      }
+    } catch (error) {
+      console.error('이메일 중복 확인 시스템 에러', error);
+      // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
+      alert('이메일 확인 중 오류가 발생했습니다.');
     }
   };
 
@@ -88,7 +97,7 @@ const RegisterPage = () => {
     onChange: () => setEmailChecked(false),
   });
 
-  const onSubmit = (data: CreateUserDto) => {
+  const onSubmit = async (data: CreateUserDto) => {
     if (!emailChecked) {
       setError('email', {
         type: 'manual',
@@ -97,8 +106,38 @@ const RegisterPage = () => {
       setFocus('email');
       return;
     }
-    // todo: 실제 API 연동 후 console.log 제거(lint 검사 때문에 넣었습니다)
-    console.log(data);
+
+    try {
+      await registerUser(data);
+      alert('회원가입이 완료되었습니다! 로그인해주세요.');
+      navigate({ to: '/login' });
+    } catch (error) {
+      // 백엔드에서 던진 에러라면 (서버에러 제외)
+      if (isAxiosError<BackendErrorResponse>(error) && error.response) {
+        const { status, data: errorData } = error.response;
+
+        // 409: 이미 가입된 유저
+        if (status === 409) {
+          alert(errorData.message || '이미 가입된 회원 정보가 존재합니다.');
+        }
+        // 400: 유효성 검증 (서버)
+        else if (status === 400 && errorData.errors) {
+          // 백엔드에서 내려준 필드별 에러를 폼에 표시
+          Object.entries(errorData.errors).forEach(([field, messages]) => {
+            setError(field as any, {
+              type: 'server',
+              message: messages[0],
+            });
+          });
+        } else {
+          // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
+          alert(errorData.message || '회원가입 중 오류가 발생했습니다.');
+        }
+      } else {
+        // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
+        alert('서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
   };
 
   return (
@@ -185,9 +224,16 @@ const RegisterPage = () => {
         <button
           type="submit"
           disabled={isSubmitting}
-          className="mt-6 w-full rounded-lg bg-primary py-3 font-semibold text-white shadow-sm transition-colors hover:bg-primary/80 focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:outline-none disabled:bg-primary/30"
+          className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-3 font-semibold text-white shadow-sm transition-colors hover:bg-primary/80 focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:outline-none disabled:bg-primary/30"
         >
-          가입하기
+          {isSubmitting ? (
+            <>
+              <Loader2 className="animate-spin" size={20} />
+              <span>가입 처리 중...</span>
+            </>
+          ) : (
+            '가입하기'
+          )}
         </button>
       </form>
 

--- a/packages/shared/types/error.ts
+++ b/packages/shared/types/error.ts
@@ -1,0 +1,5 @@
+export type BackendErrorResponse = {
+  code: string;
+  message: string;
+  errors?: Record<string, string[]>;
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #119 

<br/>

## 🔍 작업 내용

회원가입 페이지의 Mock 데이터를 제거하고 실제 백엔드 API를 연동했습니다. 서버 응답 상태에 따른 예외 처리와 UX 개선(로딩 인디케이터) 작업을 진행했습니다.

### 1. API 함수 및 타입 정의 (src/api/auth-api.ts)
- 인증 관련 API 함수를 구현했습니다.
  - 중복 확인: `checkEmailDuplicate`, `checkNicknameDuplicate` (GET /users/check-duplicate)
  - 회원가입: `registerUser` (POST /auth/register)
- 백엔드의 에러 응답 구조에 맞춰 shared에 백엔드 응답 타입을 정의했습니다.

### 2. 회원가입 로직 연동 (RegisterPage)
- 중복 검사 로직 교체:
  - 이메일(`onBlur`): 입력 완료 후 서버에 중복 확인 요청, isDuplicate 플래그로 확인하여 에러 메시지 표시.
  - 닉네임(`Debounce`): 입력 중단(0.5s) 시 서버 요청, 동일하게 isDuplicate 플래그 확인.
- 회원가입 제출(`onSubmit`):
  - 폼 제출 시 `registerUser` API 호출.
  - 성공 시 로그인 페이지(/login)로 이동.
### 3. 예외 처리 및 에러 핸들링
- Axios Error Handling: `isAxiosError`를 사용하여 타입 안전하게 에러를 처리했습니다.

### 4. 사용자 피드백:
- 중복된 값 입력 시(duplicate 응답을 true로 받으면) setError를 통해 인풋 하단에 즉시 에러 메시지 노출.
- 기타 서버 에러 발생 시 alert 처리. (추후 변경하고자 합니다)
- 로딩 인디케이터 추가: API 요청 중(isSubmitting)일 때 버튼 내부에 스피너가 돌도록 구현하고, 버튼을 비활성화하여 중복 제출을 방지했습니다.

<br/>

## 📷 스크린샷


https://github.com/user-attachments/assets/aab8b1d9-b3fe-4a85-9504-241212b2fd91



<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `5분`
> 리뷰어에게 남기고 싶은 말)

### 1. 에러 핸들링
지금은 alert나 console.log로 찍고 있는데 추후에 개발자가 확인할 수 있도록 로거 구현 or 적용하고 토스트 메시지 컴포넌트 구현해서 사용자에게 에러 발생에 대해 피드백하는 방향으로 수정하는걸 생각중입니다.

<br/>

## 📄 추가 전달 사항

저번 PR에서 빼먹은 부분인데 백엔드에서 db 수정(Users 테이블에 refreshToken 추가)에 따라서 `pnpm prisma db push` 명령을 통해 db 테이블을 업데이트 해주셔야 합니다!

그리고 백엔드(저번 PR), 프론트 둘 다 새로운 라이브러리 추가에 따라 `pnpm install` 해주시면 잘 작동할 것 같습니다.