### PR TITLE
Feat/#126 로그아웃 버튼 UI 및 기능 구현

### DIFF
--- a/apps/fe/src/apis/auth-api.ts
+++ b/apps/fe/src/apis/auth-api.ts
@@ -43,3 +43,8 @@ export const loginUser = async (data: LoginDto) => {
   const { data: responseData } = await axiosInstance.post<AuthResponseDto>('/auth/login', data);
   return responseData;
 };
+
+// 로그아웃
+export const logoutUser = async () => {
+  await axiosInstance.post('/auth/logout');
+};

--- a/apps/fe/src/components/SideBar.tsx
+++ b/apps/fe/src/components/SideBar.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 
-import { Link } from '@tanstack/react-router';
+import { logoutUser } from '@/apis/auth-api';
+import { useAuthStore } from '@/lib/stores/user-auth-store';
+import { useUserStore } from '@/lib/stores/user-store';
+import { Link, useNavigate } from '@tanstack/react-router';
 
 import {
   AudioWaveform,
@@ -13,13 +16,6 @@ import {
   User,
 } from 'lucide-react';
 
-const MOCK_PROFILE = {
-  nickname: '김개발님',
-  level: 14,
-  xp: 850,
-  profileImage: 'https://s3.ap-northeast-2.amazonaws.com/talkit/profiles/user_123.png', // 예시 이미지
-};
-
 const NAV_ITEMS = [
   { to: '/learning', label: '학습하기', icon: BookOpen },
   { to: '/battle', label: '배틀 모드', icon: Swords },
@@ -30,6 +26,22 @@ const NAV_ITEMS = [
 // 사이드 바 컴포넌트
 export const SideBar = () => {
   const [isOpen, setIsOpen] = useState(true);
+  const navigate = useNavigate();
+
+  const { clearAuth } = useAuthStore();
+  const { userInfo, clearUserInfo } = useUserStore();
+
+  const handleLogout = async () => {
+    try {
+      await logoutUser(); // API 호출
+    } catch (error) {
+      console.error('Logout failed:', error);
+    } finally {
+      clearAuth(); // 인증 상태 초기화
+      clearUserInfo(); // 유저 정보 초기화
+      navigate({ to: '/' });
+    }
+  };
 
   return (
     <aside
@@ -80,25 +92,37 @@ export const SideBar = () => {
       <div className="border-t border-gray p-4">
         <div className={`flex items-center ${isOpen ? 'gap-3' : 'justify-center'}`}>
           {/* 프로필 이미지 */}
-          <img
-            src={MOCK_PROFILE.profileImage}
-            alt="Profile"
-            className="h-10 w-10 shrink-0 rounded-full border border-gray object-cover"
-          />
+          {userInfo?.profile.profileImage ? (
+            <img
+              src={userInfo.profile.profileImage}
+              alt="Profile"
+              className="h-10 w-10 shrink-0 rounded-full border border-gray object-cover"
+            />
+          ) : (
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray text-medium-gray">
+              <User size={20} />
+            </div>
+          )}
 
           {/* 텍스트 정보 (열렸을 때만 표시) */}
           {isOpen && (
             <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-              <span className="truncate text-sm font-bold text-black">{MOCK_PROFILE.nickname}</span>
+              <span className="truncate text-sm font-bold text-black">
+                {userInfo?.profile.nickname ?? '사용자'}
+              </span>
               <span className="truncate text-xs font-medium text-dark-gray">
-                Level {MOCK_PROFILE.level} • {MOCK_PROFILE.xp} XP
+                Level {userInfo?.progression.level ?? 1} • {userInfo?.progression.currentXp ?? 0} XP
               </span>
             </div>
           )}
 
           {/* 로그아웃 아이콘 */}
           {isOpen && (
-            <button className="cursor-pointer text-dark-gray transition-colors hover:text-alert">
+            <button
+              onClick={handleLogout}
+              className="cursor-pointer text-dark-gray transition-colors hover:text-alert"
+              title="로그아웃"
+            >
               <LogOut size={20} />
             </button>
           )}

--- a/apps/fe/src/components/TopBar.tsx
+++ b/apps/fe/src/components/TopBar.tsx
@@ -1,8 +1,45 @@
-import { Link } from '@tanstack/react-router';
+import { useEffect, useRef, useState } from 'react';
 
-import { AudioWaveform } from 'lucide-react';
+import { logoutUser } from '@/apis/auth-api';
+import { useAuthStore } from '@/lib/stores/user-auth-store';
+import { useUserStore } from '@/lib/stores/user-store';
+import { Link, useNavigate } from '@tanstack/react-router';
+
+import { AudioWaveform, LogOut, User } from 'lucide-react';
 
 export const TopBar = () => {
+  const navigate = useNavigate();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const { isAuthenticated, clearAuth } = useAuthStore();
+  const { userInfo, clearUserInfo } = useUserStore();
+
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // 로그아웃 핸들러
+  const handleLogout = async () => {
+    try {
+      await logoutUser();
+    } catch (error) {
+      console.error('Logout failed:', error);
+    } finally {
+      clearAuth(); // 인증 토큰 삭제
+      clearUserInfo(); // 사용자 정보 삭제
+      setIsDropdownOpen(false);
+      navigate({ to: '/' }); // 4. 메인으로 이동
+    }
+  };
+
   return (
     <header className="sticky top-0 z-50 flex h-16 w-full items-center justify-between border-b border-gray bg-white px-4 shadow-sm md:px-8">
       <Link to="/" className="group flex items-center gap-2.5">
@@ -13,18 +50,98 @@ export const TopBar = () => {
       </Link>
 
       <div className="flex items-center gap-3">
-        <Link
-          to="/login"
-          className="hidden rounded-lg bg-gray px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-medium-gray md:inline-block"
-        >
-          로그인
-        </Link>
-        <Link
-          to="/register"
-          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/80"
-        >
-          회원가입
-        </Link>
+        {isAuthenticated ? (
+          <>
+            {/* 1. 네비게이션 메뉴 (데스크탑) */}
+            <nav className="mr-4 hidden items-center gap-6 md:flex">
+              <Link
+                to="/learning"
+                className="text-sm font-semibold text-dark-gray transition-colors hover:text-primary"
+              >
+                학습하기
+              </Link>
+              <Link
+                to="/battle"
+                className="text-sm font-semibold text-dark-gray transition-colors hover:text-primary"
+              >
+                배틀모드
+              </Link>
+              <Link
+                to="/ranking"
+                className="text-sm font-semibold text-dark-gray transition-colors hover:text-primary"
+              >
+                랭킹
+              </Link>
+            </nav>
+
+            {/* 2. 프로필 드롭다운 */}
+            <div className="relative" ref={dropdownRef}>
+              <button
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                className="flex items-center gap-2 rounded-full border border-gray p-1 pl-3 transition-colors hover:bg-gray focus:ring-2 focus:ring-primary/20 focus:outline-none"
+              >
+                <span className="hidden text-sm font-medium text-black sm:block">
+                  {userInfo?.profile.nickname ?? '사용자'} 님
+                </span>
+                {/* 프로필 이미지 영역 */}
+                <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-gray text-dark-gray">
+                  {userInfo?.profile.profileImage ? (
+                    <img
+                      src={userInfo.profile.profileImage}
+                      alt="Profile"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <User size={18} />
+                  )}
+                </div>
+              </button>
+
+              {/* 드롭다운 메뉴 본문 */}
+              {isDropdownOpen && (
+                <div className="ring-opacity-5 animate-in fade-in zoom-in-95 absolute right-0 mt-2 w-48 origin-top-right rounded-xl border border-gray bg-white py-1 shadow-lg ring-1 ring-black duration-100">
+                  <div className="border-b border-gray px-4 py-3 sm:hidden">
+                    <p className="truncate text-sm font-medium text-black">
+                      {userInfo?.profile.nickname ?? '사용자'}
+                    </p>
+                  </div>
+
+                  <Link
+                    to="/mypage"
+                    className="flex w-full items-center rounded-xl px-4 py-2 text-sm text-dark-gray transition-colors hover:bg-gray hover:text-primary"
+                    onClick={() => setIsDropdownOpen(false)}
+                  >
+                    <User className="mr-2 h-4 w-4" />
+                    마이페이지
+                  </Link>
+
+                  <button
+                    onClick={handleLogout}
+                    className="flex w-full items-center rounded-xl px-4 py-2 text-sm text-alert transition-colors hover:bg-red-50"
+                  >
+                    <LogOut className="mr-2 h-4 w-4" />
+                    로그아웃
+                  </button>
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            <Link
+              to="/login"
+              className="hidden rounded-lg bg-gray px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-medium-gray md:inline-block"
+            >
+              로그인
+            </Link>
+            <Link
+              to="/register"
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/80"
+            >
+              회원가입
+            </Link>
+          </>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## 🔗 관련 이슈

- close #126 

<br/>

## 🔍 작업 내용

사용자의 로그인 상태(isAuthenticated)에 따라 헤더(TopBar)와 사이드바(SideBar)의 UI를 조건부 렌더링하고, 로그아웃 기능을 구현했습니다.

### 1. 로그아웃 로직 구현
- API 연동: POST /auth/logout 엔드포인트를 호출하는 `logoutUser` 함수를 추가했습니다.
- 상태 초기화: 로그아웃 시 `useAuthStore` (인증 정보)와 `useUserStore` (유저 프로필 정보)를 모두 null/false로 초기화합니다.
- 리다이렉트: 로그아웃 완료 후 메인 페이지(/)로 이동합니다.

### 2. UI 개선 (Header & Sidebar)
- TopBar (헤더):
  - 로그인 시: 메인 네비게이션과 프로필 드롭다운을 노출합니다.
  - 비로그인 시: 기존의 '로그인/회원가입' 버튼을 노출합니다.
  - 드롭다운: 프로필 클릭 시 '마이페이지', '로그아웃' 메뉴가 나타나며, 외부 클릭 시 닫히도록 `useRef`로 처리했습니다.
- SideBar (사이드바):
  - Mock 데이터를 제거하고 `UserStore`의 실제 유저 데이터(닉네임, 레벨, XP, 프로필 이미지)를 연동했습니다.
  - 하단에 로그아웃 버튼을 추가하고 기능을 연결했습니다.

<br/>

## 📷 스크린샷


https://github.com/user-attachments/assets/0fbcb17c-3c87-4f8c-8591-e0e7f7eff551



<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `3분`
> 리뷰어에게 남기고 싶은 말) 

현재는 userInfo를  업데이트하는 로직이 미구현인데 추후에 `/users/me` api 구현하면서 연동하고 해결하려고 합니다.

<br/>

## 📄 추가 전달 사항

