### PR TITLE
Feat/#125 토큰 자동 갱신 로직 구현

### DIFF
--- a/apps/fe/src/apis/auth-api.ts
+++ b/apps/fe/src/apis/auth-api.ts
@@ -48,3 +48,9 @@ export const loginUser = async (data: LoginDto) => {
 export const logoutUser = async () => {
   await axiosInstance.post('/auth/logout');
 };
+
+// 토큰 재발급
+export const refreshAccessTokenApi = async () => {
+  const { data } = await axiosInstance.post<AuthResponseDto>('/auth/refresh');
+  return data;
+};

--- a/apps/fe/src/apis/http.ts
+++ b/apps/fe/src/apis/http.ts
@@ -1,7 +1,9 @@
 import { ENV } from '@/constants/env';
 import { useAuthStore } from '@/lib/stores/user-auth-store';
+import { useUserStore } from '@/lib/stores/user-store';
 
-import axios, { type AxiosInstance } from 'axios';
+import { refreshAccessTokenApi } from './auth-api';
+import axios, { AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
 
 const axiosInstance: AxiosInstance = axios.create({
   baseURL: ENV.API_URL,
@@ -32,11 +34,48 @@ axiosInstance.interceptors.response.use(
   (response) => {
     return response;
   },
-  async (error) => {
-    // TODO: 401 Unauthorized 에러 발생 시 토큰 재발급(Silent Refresh) 로직
-    // 백엔드의 GET /auth/refresh 엔드포인트를 호출 (Task 3-3-4)
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // refresh 요청 경로에서 401이 뜬거면 무한 루프 방지를 위해 바로 실패 처리
+      if (originalRequest.url?.includes('/auth/refresh')) {
+        handleAuthError();
+        return Promise.reject(error);
+      }
+
+      originalRequest._retry = true;
+
+      try {
+        // 1. 토큰 재발급 시도
+        const { accessToken } = await refreshAccessTokenApi();
+
+        useAuthStore.getState().setAccessToken(accessToken);
+
+        // 실패했던 원래 요청의 헤더를 새 토큰으로 교체
+        if (originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        }
+
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        handleAuthError();
+        return Promise.reject(refreshError);
+      }
+    }
 
     return Promise.reject(error);
   },
 );
+
+// 인증 에러 공통 처리 함수
+const handleAuthError = () => {
+  useAuthStore.getState().clearAuth();
+  useUserStore.getState().clearUserInfo();
+
+  // React Router 밖이므로 window.location 사용
+  if (window.location.pathname !== '/login') {
+    window.location.href = '/login';
+  }
+};
 export default axiosInstance;

--- a/apps/fe/src/lib/stores/user-auth-store.ts
+++ b/apps/fe/src/lib/stores/user-auth-store.ts
@@ -1,3 +1,5 @@
+import { refreshAccessTokenApi } from '@/apis/auth-api';
+
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
@@ -5,10 +7,12 @@ type AuthState = {
   // State
   accessToken: string | null;
   isAuthenticated: boolean;
+  isInitializing: boolean;
 
   // Actions
   setAccessToken: (token: string | null) => void;
   clearAuth: () => void; // 로그아웃 시 호출
+  checkAuth: () => Promise<void>;
 };
 
 export const useAuthStore = create<AuthState>()(
@@ -16,11 +20,29 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       accessToken: null,
       isAuthenticated: false,
+      isInitializing: true,
 
       setAccessToken: (token) =>
         set({ accessToken: token, isAuthenticated: !!token }, false, 'auth/setAccessToken'),
 
       clearAuth: () => set({ accessToken: null, isAuthenticated: false }, false, 'auth/clearAuth'),
+
+      checkAuth: async () => {
+        try {
+          const { accessToken } = await refreshAccessTokenApi();
+          set({
+            accessToken,
+            isAuthenticated: true,
+            isInitializing: false, // 확인 완료 (성공)
+          });
+        } catch (error) {
+          set({
+            accessToken: null,
+            isAuthenticated: false,
+            isInitializing: false, // 확인 완료 (실패 -> 비로그인)
+          });
+        }
+      },
     }),
     { name: 'AuthStore' },
   ),

--- a/apps/fe/src/routes/__root.tsx
+++ b/apps/fe/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { Footer } from '@/components/Footer';
 import { TopBar } from '@/components/TopBar';
+import { useAuthStore } from '@/lib/stores/user-auth-store';
 import { Outlet, createRootRoute } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 
@@ -40,4 +41,13 @@ const RootLayout = () => {
 export const Route = createRootRoute({
   component: RootLayout,
   notFoundComponent: NotFoundComponent,
+
+  beforeLoad: async () => {
+    const { isInitializing, checkAuth } = useAuthStore.getState();
+
+    // 아직 초기화가 안 되었다면(앱 최초 실행) 체크 시도
+    if (isInitializing) {
+      await checkAuth();
+    }
+  },
 });


### PR DESCRIPTION
## 🔗 관련 이슈

- close #125 

<br/>

## 🔍 작업 내용

Access Token 만료 시 백그라운드에서 토큰을 갱신하는 Silent Refresh 로직을 구현했습니다. 
추가로 새로고침 시 로그인 상태가 유지되도록 하는 로직을 추가했습니다.

### 1. Axios Interceptor
- 401 에러 감지: Response Interceptor에서 401 Unauthorized 에러를 감지하여 토큰 갱신을 시도합니다.

- 보안 처리: Refresh 요청마저 실패하거나 토큰이 유효하지 않은 경우, 즉시 로그아웃 처리(`handleAuthError`)하고 로그인 페이지로 이동합니다.

### 2. 앱 초기화 로직 
- 새로고침 대응: 앱이 실행될 때(RootLayout 마운트 시) checkAuth를 호출하여 유효한 Refresh Token이 있다면 Access Token을 복구합니다.

### 3. 기타 API 및 스토어
- API: POST /auth/refresh 엔드포인트를 호출하는 refreshAccessTokenApi 함수 추가.
- Store: isInitializing 상태와 checkAuth 액션 추가.

<br/>

## 📷 스크린샷

ui 변경사항이 있다면 추가 + 테스트 커버리지도 좋음!

<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `5분`
> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

초기화(토큰발급)하는 동안 스피너 로딩 UI를 보여주는 걸 고려했었으나. 이 경우에는 beforeLoad 대신 useEffect()를 사용하여 리액트의 훅 플로우에 따라 브라우저 paint screen 이후 Run Effect 가 진행됨에 따라 우선 렌더링 -> 화면 paint -> 로딩 스피너 화면 -> useEffect() 내부 함수 실행 후 -> 반영

이 순서가 되는데 우선은 초기화 UX의 경우 tanstack router의 beforeLoad 방식을 택하였습니다. 
<br/>

## 📄 추가 전달 사항

