### PR TITLE
Feat/#157 답변 제출 후 수정 불가 처리

### DIFF
--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -8,6 +8,7 @@ const AnswerSection = () => {
   const [editText, setEditText] = useState('');
 
   const isSttLoading = phase === ANSWER_PHASE.STT_LOADING;
+  const isSttDone = phase === ANSWER_PHASE.STT_DONE;
   const isEditEmpty = isEditing && !editText.trim();
 
   const shouldShow = phase !== ANSWER_PHASE.IDLE && phase !== ANSWER_PHASE.RECORDING;
@@ -32,7 +33,7 @@ const AnswerSection = () => {
       <h3 className="sr-only">음성 인식 결과</h3>
       <div className="flex items-center justify-between">
         <p className="text-xl font-bold">나의 답변</p>
-        {!isSttLoading && (
+        {isSttDone && (
           <div className="flex gap-2">
             {isEditing && (
               <button

--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ANSWER_PHASE, useAnswerFlow } from '@/features/learning/lib/contexts/answer-flow-context';
 
@@ -10,6 +10,12 @@ const AnswerSection = () => {
   const isSttLoading = phase === ANSWER_PHASE.STT_LOADING;
   const isSttDone = phase === ANSWER_PHASE.STT_DONE;
   const isEditEmpty = isEditing && !editText.trim();
+
+  useEffect(() => {
+    if (!isSttDone && isEditing) {
+      setIsEditing(false);
+    }
+  }, [isSttDone, isEditing]);
 
   const shouldShow = phase !== ANSWER_PHASE.IDLE && phase !== ANSWER_PHASE.RECORDING;
   if (!shouldShow) return null;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #157

<br/>

## 🔍 작업 내용

**`apps/fe/src/features/learning/components/question/answer-section.tsx`**

- 수정 버튼 노출 조건을 `!isSttLoading`에서 `isSttDone`으로 변경하여, `STT_DONE` 단계에서만 수정 버튼이 표시되도록 처리
- `useEffect`를 추가하여 `STT_DONE` 이후 단계(피드백 요청 등)로 전환 시 편집 모드를 자동 해제

<br/>

## 📷 스크린샷

https://github.com/user-attachments/assets/1be62db6-0d02-4be6-92c5-c6b143e0aa2f



<br/>

## ✅ 체크리스트

- [x]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [x]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: 5분


<br/>

## 📄 추가 전달 사항

- `ANSWER_PHASE` 흐름: `IDLE → RECORDING → STT_LOADING → STT_DONE → FEEDBACK_LOADING → FEEDBACK_DONE`
- 기존에는 `STT_LOADING`만 아니면 수정 버튼이 보였으나, 이제 `STT_DONE` 상태에서만 노출됩니다.