### PR TITLE
Fix/#160 shared 패키지 빌드 설정 및 학습 UI 버그 수정

### DIFF
--- a/apps/be/src/modules/assessment/assessment.service.spec.ts
+++ b/apps/be/src/modules/assessment/assessment.service.spec.ts
@@ -38,7 +38,7 @@ describe('AssessmentService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new AssessmentService(repo, worker, userCreditsRepo, sessionsService);
+    service = new AssessmentService(repo, worker, userCreditsRepo);
   });
 
   describe('submitAndAssess', () => {

--- a/apps/be/src/modules/assessment/assessment.service.ts
+++ b/apps/be/src/modules/assessment/assessment.service.ts
@@ -7,6 +7,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 
+import { UserCreditsRepository } from '@/users/credits/user-credits.repository';
 import { AssessmentStatus } from '@prisma/client';
 
 import { AssessmentRepository } from './assessment.repository';
@@ -37,6 +38,7 @@ export class AssessmentService {
   constructor(
     private readonly repo: AssessmentRepository,
     private readonly worker: AssessmentWorker,
+    private readonly userCreditsRepository: UserCreditsRepository,
   ) {}
 
   async submitAndAssess(
@@ -181,6 +183,8 @@ export class AssessmentService {
       }
     })();
 
+    const remainingToken = await this.userCreditsRepository.getTotalCredit(userId);
+
     return {
       // shared DTO 스키마에 맞춰 필드를 매핑합니다.
       answerId: answer.id,
@@ -191,7 +195,7 @@ export class AssessmentService {
       weaknesses,
       suggestions,
       xp,
-      remainingToken: 0, // 토큰 잔여량 추적 미구현으로 0 반환
+      remainingToken: remainingToken,
     };
   }
 }

--- a/apps/be/src/modules/assessment/sse/assessment.sse.controller.spec.ts
+++ b/apps/be/src/modules/assessment/sse/assessment.sse.controller.spec.ts
@@ -27,7 +27,7 @@ describe('AssessmentSseController - 스냅샷 DTO 매핑', () => {
 
     const ctrl = new AssessmentSseController(bus as any, repo);
 
-    const obs = ctrl.sse('123');
+    const obs = ctrl.sse({ id: 1 }, 1, '123');
     const sub = (obs as any).subscribe({
       next: (evt: any) => {
         const data: any = evt.data;

--- a/apps/be/src/modules/assessment/sse/assessment.sse.controller.ts
+++ b/apps/be/src/modules/assessment/sse/assessment.sse.controller.ts
@@ -18,9 +18,9 @@ export class AssessmentSseController {
     private readonly repo: AssessmentRepository,
   ) {}
 
-  @Sse(':answerId/assess/stream')
+  // @Sse(':answerId/assess/stream')
   @ApiOperation({ summary: '평가 진행 상황 SSE 스트림 (BullMQ QueueEvents 기반)' })
-  //@Sse(':sessionId/answers/:answerId/assess/stream')
+  @Sse(':sessionId/answers/:answerId/assess/stream')
   @UseGuards(JwtAuthGuard)
   //@ApiOperation({ summary: '평가 진행 상황 SSE 스트림' })
   @ApiParam({ name: 'answerId', type: Number })

--- a/apps/fe/src/features/learning/components/question/answer-section.tsx
+++ b/apps/fe/src/features/learning/components/question/answer-section.tsx
@@ -39,7 +39,7 @@ const AnswerSection = () => {
       <h3 className="sr-only">음성 인식 결과</h3>
       <div className="flex items-center justify-between">
         <p className="text-xl font-bold">나의 답변</p>
-        {isSttDone && (
+        {isSttDone && sttText?.trim() && (
           <div className="flex gap-2">
             {isEditing && (
               <button
@@ -67,24 +67,22 @@ const AnswerSection = () => {
             <div className="loader-dots" />
             <p className="text-dark-gray">AI가 음성을 텍스트로 변환하고 있어요</p>
           </div>
+        ) : isEditing ? (
+          <>
+            <textarea
+              className={`w-full resize-none rounded-md border p-3 focus:outline-none ${
+                isEditEmpty
+                  ? 'border-red-500 focus:border-red-500'
+                  : 'border-gray focus:border-primary'
+              }`}
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              rows={4}
+            />
+            {isEditEmpty && <p className="mt-1 text-sm text-red-500">답변을 입력해 주세요</p>}
+          </>
         ) : sttText?.trim() ? (
-          isEditing ? (
-            <>
-              <textarea
-                className={`w-full resize-none rounded-md border p-3 focus:outline-none ${
-                  isEditEmpty
-                    ? 'border-red-500 focus:border-red-500'
-                    : 'border-gray focus:border-primary'
-                }`}
-                value={editText}
-                onChange={(e) => setEditText(e.target.value)}
-                rows={4}
-              />
-              {isEditEmpty && <p className="mt-1 text-sm text-red-500">답변을 입력해 주세요</p>}
-            </>
-          ) : (
-            <p>{sttText}</p>
-          )
+          <p>{sttText}</p>
         ) : (
           <p>음성이 인식되지 않았어요. 다시 녹음해 주세요</p>
         )}

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -94,7 +94,16 @@ const FloatingStepBar = () => {
 
   return (
     <ActionBar>
-      <ActionBar.Button onClick={handleEndLearning} withDivider>
+      <ActionBar.Button
+        onClick={handleEndLearning}
+        withDivider
+        disabled={phase === ANSWER_PHASE.FEEDBACK_LOADING || phase === ANSWER_PHASE.STT_LOADING}
+        disabledReason={
+          phase === ANSWER_PHASE.FEEDBACK_LOADING
+            ? '피드백이 완료된 후 이용할 수 있어요'
+            : '음성 인식이 완료된 후 제출할 수 있어요'
+        }
+      >
         학습 종료
       </ActionBar.Button>
       {isFeedbackPhase ? (


### PR DESCRIPTION
## 🔗 관련 이슈
- close #160 

## 🔍 작업 내용

**`apps/be/src/modules/assessment/assessment.service.ts`**

- `UserCreditsRepository` 의존성 주입 추가
- 평가 완료 시 `remainingToken`을 하드코딩(0) 대신 실제 잔여 크레딧을 조회하여 반환하도록 수정

**`apps/be/src/modules/assessment/assessment.service.spec.ts`**

- 생성자에서 제거된 `sessionsService` 의존성을 테스트 코드에서도 제거

**`apps/be/src/modules/assessment/sse/assessment.sse.controller.ts`**

- SSE 라우트 경로를 `:answerId/assess/stream`에서 `:sessionId/answers/:answerId/assess/stream`으로 변경

**`apps/be/src/modules/assessment/sse/assessment.sse.controller.spec.ts`**

- 변경된 `sse()` 메서드 시그니처에 맞게 테스트 코드 수정

**`apps/fe/src/features/learning/components/question/answer-section.tsx`**

- STT 완료 후 텍스트가 빈 문자열일 때 수정/제출 버튼이 노출되지 않도록 `sttText?.trim()` 조건 추가
- 중첩 삼항 연산자를 평탄화하여 가독성 개선

**`apps/fe/src/features/learning/components/question/floating-step-bar.tsx`**

- `FEEDBACK_LOADING` 또는 `STT_LOADING` 상태에서 학습 종료 버튼에 `disabled` 속성 추가
- 각 상태에 맞는 비활성화 사유 메시지(`disabledReason`) 표시

<br/>

## 📷 스크린샷

<br/>

## ✅ 체크리스트

- [ ]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [ ]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [ ]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: `10분`


<br/>

## 📄 추가 전달 사항

- `remainingToken`이 기존에 `0`으로 하드코딩되어 있던 부분을 실제 크레딧 조회로 변경했습니다.
- SSE 라우트 경로가 세션 기반 URL 구조(`/sessions/:sessionId/answers/:answerId/...`)로 통일되었습니다.