### PR TITLE
Feat/#182 크레딧 0일 때 다음 질문 및 딥다이브 기능 차단

### DIFF
--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -1,165 +1,43 @@
-import { type ReactNode, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 
-import {
-  finishSessionApi,
-  getDeepDiveQuestionApi,
-  getNextQuestionApi,
-  submitAssessApi,
-} from '@/apis/learning-api';
-import useLearningSession from '@/lib/stores/learning-session';
 import { cn } from '@/lib/utils';
 import * as Tooltip from '@radix-ui/react-tooltip';
-import type { FinishSessionResponseDTO } from '@repo/shared/types/learning';
 
-import { ANSWER_PHASE, useAnswerFlow } from '../../lib/contexts/answer-flow-context';
+import useFloatingStepBarActions from '../../lib/hooks/use-floating-step-bar-actions';
 import RewardModal from './reward-modal';
 import { Binoculars, SkipForward } from 'lucide-react';
 
 const FloatingStepBar = () => {
-  const sessionId = useLearningSession((state) => state.sessionId);
-  const question = useLearningSession((state) => state.question);
-  const remainedCredit = useLearningSession((state) => state.remainedCredit);
-
-  const {
-    phase,
-    setPhase,
-    sttText,
-    setAnswerId,
-    answerId,
-    recordingTime,
-    reset,
-    isInsufficientAnswer,
-  } = useAnswerFlow();
-
-  const [rewardData, setRewardData] = useState<FinishSessionResponseDTO | null>(null);
-  const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
-  const clickedButtonsRef = useRef<Set<string>>(new Set());
-
-  const isFeedbackPhase =
-    phase === ANSWER_PHASE.FEEDBACK_LOADING || phase === ANSWER_PHASE.FEEDBACK_DONE;
-
-  const markClicked = (buttonName: string) => {
-    clickedButtonsRef.current.add(buttonName);
-  };
-
-  const isClicked = (buttonName: string) => clickedButtonsRef.current.has(buttonName);
-
-  const handleEndLearning = async () => {
-    if (!sessionId || isClicked('endLearning')) return;
-    markClicked('endLearning');
-
-    const data = await finishSessionApi({ sessionId });
-    setRewardData(data);
-    setIsRewardModalOpen(true);
-  };
-
-  const handleSubmitAnswer = async () => {
-    if (!sessionId || !question || !sttText || isClicked('submitAnswer')) return;
-    markClicked('submitAnswer');
-
-    try {
-      setPhase(ANSWER_PHASE.FEEDBACK_LOADING);
-      const { answerId: newAnswerId } = await submitAssessApi({
-        sessionId,
-        questionId: question.questionId,
-        extraQuestionId: question.extraQuestionId,
-        answerText: sttText,
-        timeSpentSec: recordingTime,
-      });
-
-      setAnswerId(newAnswerId);
-    } catch (error) {
-      console.error('평가 제출 실패:', error);
-    }
-  };
-
-  const handleNextQuestion = () => {
-    if (!sessionId || isClicked('nextQuestion')) return;
-    markClicked('nextQuestion');
-
-    reset();
-    getNextQuestionApi(sessionId).then((data) => {
-      useLearningSession.getState().setQuestion({ ...data, sessionId });
-    });
-  };
-
-  const handleDeepDive = () => {
-    if (!sessionId || !answerId || isClicked('deepDive')) return;
-    markClicked('deepDive');
-
-    getDeepDiveQuestionApi(sessionId, answerId).then((data) => {
-      reset();
-      useLearningSession.getState().setQuestion({ ...data, sessionId });
-    });
-  };
+  const { endLearning, deepDive, nextQuestion, submitAnswer, isFeedbackPhase, rewardModal } =
+    useFloatingStepBarActions();
 
   return (
     <ActionBar>
-      <ActionBar.Button
-        onClick={handleEndLearning}
-        withDivider
-        disabled={phase === ANSWER_PHASE.FEEDBACK_LOADING || phase === ANSWER_PHASE.STT_LOADING}
-        disabledReason={
-          phase === ANSWER_PHASE.FEEDBACK_LOADING
-            ? '피드백이 완료된 후 이용할 수 있어요'
-            : '음성 인식이 완료된 후 제출할 수 있어요'
-        }
-      >
+      <ActionBar.Button {...endLearning} withDivider>
         학습 종료
       </ActionBar.Button>
       {isFeedbackPhase ? (
         <>
-          <ActionBar.Button
-            onClick={handleDeepDive}
-            disabled={
-              phase !== ANSWER_PHASE.FEEDBACK_DONE || isInsufficientAnswer || remainedCredit === 0
-            }
-            disabledReason={
-              phase !== ANSWER_PHASE.FEEDBACK_DONE
-                ? '피드백이 완료된 후 이용할 수 있어요'
-                : '답변이 충분하지 않아 딥다이브를 할 수 없어요'
-            }
-            className="flex items-center gap-2"
-          >
+          <ActionBar.Button {...deepDive} className="flex items-center gap-2">
             <Binoculars className="hidden h-4 w-4 sm:block" />
             딥다이브
           </ActionBar.Button>
-          <ActionBar.PrimaryButton
-            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || remainedCredit === 0}
-            disabledReason="피드백이 완료된 후 이용할 수 있어요"
-            onClick={handleNextQuestion}
-          >
-            다음 질문
-          </ActionBar.PrimaryButton>
+          <ActionBar.PrimaryButton {...nextQuestion}>다음 질문</ActionBar.PrimaryButton>
         </>
       ) : (
         <>
-          <ActionBar.Button
-            onClick={handleNextQuestion}
-            disabled={remainedCredit === 0}
-            className="flex items-center gap-2"
-          >
+          <ActionBar.Button {...nextQuestion} className="flex items-center gap-2">
             <SkipForward className="hidden h-4 w-4 sm:block" />
             다음 질문으로 건너뛰기
           </ActionBar.Button>
-          <ActionBar.PrimaryButton
-            disabled={phase !== ANSWER_PHASE.STT_DONE || !sttText || remainedCredit === 0}
-            disabledReason={
-              !sttText
-                ? '인식된 답변이 없어요. 다시 녹음해 주세요'
-                : '음성 인식이 완료된 후 제출할 수 있어요'
-            }
-            onClick={handleSubmitAnswer}
-          >
-            답변 제출하기
-          </ActionBar.PrimaryButton>
+          <ActionBar.PrimaryButton {...submitAnswer}>답변 제출하기</ActionBar.PrimaryButton>
         </>
       )}
-      {rewardData && (
+      {rewardModal.data && (
         <RewardModal
-          data={rewardData}
-          isModalOpen={isRewardModalOpen}
-          onOpenChange={setIsRewardModalOpen}
+          data={rewardModal.data}
+          isModalOpen={rewardModal.isOpen}
+          onOpenChange={rewardModal.onOpenChange}
         />
       )}
     </ActionBar>

--- a/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
+++ b/apps/fe/src/features/learning/components/question/floating-step-bar.tsx
@@ -18,6 +18,7 @@ import { Binoculars, SkipForward } from 'lucide-react';
 const FloatingStepBar = () => {
   const sessionId = useLearningSession((state) => state.sessionId);
   const question = useLearningSession((state) => state.question);
+  const remainedCredit = useLearningSession((state) => state.remainedCredit);
 
   const {
     phase,
@@ -110,7 +111,9 @@ const FloatingStepBar = () => {
         <>
           <ActionBar.Button
             onClick={handleDeepDive}
-            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || isInsufficientAnswer}
+            disabled={
+              phase !== ANSWER_PHASE.FEEDBACK_DONE || isInsufficientAnswer || remainedCredit === 0
+            }
             disabledReason={
               phase !== ANSWER_PHASE.FEEDBACK_DONE
                 ? '피드백이 완료된 후 이용할 수 있어요'
@@ -122,7 +125,7 @@ const FloatingStepBar = () => {
             딥다이브
           </ActionBar.Button>
           <ActionBar.PrimaryButton
-            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE}
+            disabled={phase !== ANSWER_PHASE.FEEDBACK_DONE || remainedCredit === 0}
             disabledReason="피드백이 완료된 후 이용할 수 있어요"
             onClick={handleNextQuestion}
           >
@@ -131,12 +134,16 @@ const FloatingStepBar = () => {
         </>
       ) : (
         <>
-          <ActionBar.Button onClick={handleNextQuestion} className="flex items-center gap-2">
+          <ActionBar.Button
+            onClick={handleNextQuestion}
+            disabled={remainedCredit === 0}
+            className="flex items-center gap-2"
+          >
             <SkipForward className="hidden h-4 w-4 sm:block" />
             다음 질문으로 건너뛰기
           </ActionBar.Button>
           <ActionBar.PrimaryButton
-            disabled={phase !== ANSWER_PHASE.STT_DONE || !sttText}
+            disabled={phase !== ANSWER_PHASE.STT_DONE || !sttText || remainedCredit === 0}
             disabledReason={
               !sttText
                 ? '인식된 답변이 없어요. 다시 녹음해 주세요'

--- a/apps/fe/src/features/learning/lib/hooks/use-floating-step-bar-actions.ts
+++ b/apps/fe/src/features/learning/lib/hooks/use-floating-step-bar-actions.ts
@@ -1,0 +1,175 @@
+import { useRef, useState } from 'react';
+
+import {
+  finishSessionApi,
+  getDeepDiveQuestionApi,
+  getNextQuestionApi,
+  submitAssessApi,
+} from '@/apis/learning-api';
+import useLearningSession from '@/lib/stores/learning-session';
+import type { FinishSessionResponseDTO } from '@repo/shared/types/learning';
+
+import { ANSWER_PHASE, useAnswerFlow } from '../contexts/answer-flow-context';
+
+const getEndLearningDisabledReason = (phase: string) => {
+  if (phase === ANSWER_PHASE.FEEDBACK_LOADING) return '피드백이 완료된 후 이용할 수 있어요';
+  if (phase === ANSWER_PHASE.STT_LOADING) return '음성 인식이 완료된 후 이용할 수 있어요';
+  return undefined;
+};
+
+const getDeepDiveDisabledReason = (
+  phase: string,
+  isInsufficientAnswer: boolean,
+  remainedCredit: number | null,
+) => {
+  if (!remainedCredit) return '크레딧이 부족해요';
+  if (phase !== ANSWER_PHASE.FEEDBACK_DONE) return '피드백이 완료된 후 이용할 수 있어요';
+  if (isInsufficientAnswer) return '답변이 충분하지 않아 딥다이브를 할 수 없어요';
+  return undefined;
+};
+
+const getNextQuestionDisabledReason = (
+  phase: string,
+  isFeedbackPhase: boolean,
+  remainedCredit: number | null,
+) => {
+  if (!remainedCredit) return '크레딧이 부족해요';
+  if (isFeedbackPhase && phase !== ANSWER_PHASE.FEEDBACK_DONE)
+    return '피드백이 완료된 후 이용할 수 있어요';
+  return undefined;
+};
+
+const getSubmitAnswerDisabledReason = (
+  phase: string,
+  sttText: string | null,
+  remainedCredit: number | null,
+) => {
+  if (!remainedCredit) return '크레딧이 부족해요';
+  if (!sttText) return '인식된 답변이 없어요. 다시 녹음해 주세요';
+  if (phase !== ANSWER_PHASE.STT_DONE) return '음성 인식이 완료된 후 제출할 수 있어요';
+  return undefined;
+};
+
+type ButtonProps = {
+  onClick: () => void;
+  disabled: boolean;
+  disabledReason?: string;
+};
+
+const useFloatingStepBarActions = () => {
+  const sessionId = useLearningSession((state) => state.sessionId);
+  const question = useLearningSession((state) => state.question);
+  const remainedCredit = useLearningSession((state) => state.remainedCredit);
+
+  const {
+    phase,
+    setPhase,
+    sttText,
+    setAnswerId,
+    answerId,
+    recordingTime,
+    reset,
+    isInsufficientAnswer,
+  } = useAnswerFlow();
+
+  const [rewardData, setRewardData] = useState<FinishSessionResponseDTO | null>(null);
+  const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
+  const clickedButtonsRef = useRef<Set<string>>(new Set());
+
+  const isFeedbackPhase =
+    phase === ANSWER_PHASE.FEEDBACK_LOADING || phase === ANSWER_PHASE.FEEDBACK_DONE;
+
+  const markClicked = (buttonName: string) => {
+    clickedButtonsRef.current.add(buttonName);
+  };
+
+  const isClicked = (buttonName: string) => clickedButtonsRef.current.has(buttonName);
+
+  const handleEndLearning = async () => {
+    if (!sessionId || isClicked('endLearning')) return;
+    markClicked('endLearning');
+
+    const data = await finishSessionApi({ sessionId });
+    setRewardData(data);
+    setIsRewardModalOpen(true);
+  };
+
+  const handleSubmitAnswer = async () => {
+    if (!sessionId || !question || !sttText || isClicked('submitAnswer')) return;
+    markClicked('submitAnswer');
+
+    try {
+      setPhase(ANSWER_PHASE.FEEDBACK_LOADING);
+      const { answerId: newAnswerId } = await submitAssessApi({
+        sessionId,
+        questionId: question.questionId,
+        extraQuestionId: question.extraQuestionId,
+        answerText: sttText,
+        timeSpentSec: recordingTime,
+      });
+
+      setAnswerId(newAnswerId);
+    } catch (error) {
+      console.error('평가 제출 실패:', error);
+    }
+  };
+
+  const handleNextQuestion = () => {
+    if (!sessionId || isClicked('nextQuestion')) return;
+    markClicked('nextQuestion');
+
+    reset();
+    getNextQuestionApi(sessionId).then((data) => {
+      useLearningSession.getState().setQuestion({ ...data, sessionId });
+    });
+  };
+
+  const handleDeepDive = () => {
+    if (!sessionId || !answerId || isClicked('deepDive')) return;
+    markClicked('deepDive');
+
+    getDeepDiveQuestionApi(sessionId, answerId).then((data) => {
+      reset();
+      useLearningSession.getState().setQuestion({ ...data, sessionId });
+    });
+  };
+
+  const endLearning: ButtonProps = {
+    onClick: handleEndLearning,
+    disabled: phase === ANSWER_PHASE.FEEDBACK_LOADING || phase === ANSWER_PHASE.STT_LOADING,
+    disabledReason: getEndLearningDisabledReason(phase),
+  };
+
+  const deepDive: ButtonProps = {
+    onClick: handleDeepDive,
+    disabled: phase !== ANSWER_PHASE.FEEDBACK_DONE || isInsufficientAnswer || !remainedCredit,
+    disabledReason: getDeepDiveDisabledReason(phase, isInsufficientAnswer, remainedCredit),
+  };
+
+  const nextQuestion: ButtonProps = {
+    onClick: handleNextQuestion,
+    disabled: !remainedCredit || (isFeedbackPhase && phase !== ANSWER_PHASE.FEEDBACK_DONE),
+    disabledReason: getNextQuestionDisabledReason(phase, isFeedbackPhase, remainedCredit),
+  };
+
+  const submitAnswer: ButtonProps = {
+    onClick: handleSubmitAnswer,
+    disabled: phase !== ANSWER_PHASE.STT_DONE || !sttText || !remainedCredit,
+    disabledReason: getSubmitAnswerDisabledReason(phase, sttText, remainedCredit),
+  };
+
+  return {
+    endLearning,
+    deepDive,
+    nextQuestion,
+    submitAnswer,
+    isFeedbackPhase,
+    rewardModal: {
+      data: rewardData,
+      isOpen: isRewardModalOpen,
+      onOpenChange: setIsRewardModalOpen,
+    },
+  };
+};
+
+export default useFloatingStepBarActions;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #182

<br/>

## 🔍 작업 내용

### 1. 크레딧이 0일 때 다음 질문 및 딥다이브 기능 차단

- 남은 크레딧(`remainedCredit`)이 0인 경우 **다음 질문**, **딥다이브**, **답변 제출** 버튼을 비활성화하여 더 이상 학습을 진행할 수 없도록 차단
- 비활성화된 버튼에 `'크레딧이 부족해요'` 툴팁을 노출하여 사용자가 원인을 파악할 수 있도록 안내
- 학습 종료 버튼은 크레딧과 무관하게 항상 사용 가능하도록 유지

### 2. FloatingStepBar 비즈니스 로직 분리

- 컴포넌트에 혼재되어 있던 API 호출, 상태 관리, disabled 조건 판별 로직을 `useFloatingStepBarActions` 커스텀 훅으로 분리
- 각 버튼(`endLearning`, `deepDive`, `nextQuestion`, `submitAnswer`)의 `onClick`, `disabled`, `disabledReason`을 훅에서 계산하여 반환하고, 컴포넌트에서는 spread로 전달만 하도록 변경
- 이를 통해 FloatingStepBar 컴포넌트는 순수 UI 렌더링 역할만 담당하도록 축소

<br/>

## 📷 스크린샷

<table>
  <thead>
    <tr>
      <th>답변 하기 전</th>
      <th>피드백 받고 난 후</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
          <video src="https://github.com/user-attachments/assets/fbfad686-f3cf-4772-8269-20a7931dc1fc.mp4" />
      </td>
      <td>
         <video src="https://github.com/user-attachments/assets/48ae22b7-ecdf-44e8-be39-ff13d4d733f8.mp4" />
      </td>
    </tr>
  </tbody>
</table>
<br/>



## ✅ 체크리스트

- [x]  기능이 의도대로 정상 동작하는지 확인했습니다.
- [ ]  에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x]  관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x]  배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x]  연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항

- 리뷰 예상 시간: `10분`

<br/>
