### PR TITLE
Refactor/#178 로그인후 사용자 정보 조회 및 상태 업데이트 로직 추가

### DIFF
--- a/apps/be/src/auth/auth.controller.ts
+++ b/apps/be/src/auth/auth.controller.ts
@@ -23,8 +23,10 @@ import { ActiveUser } from '@/common/decorators/active-user.decorator';
 import { ZodValidationPipe } from '@/common/pipes/zod-validation.pipe';
 import { zodSchemaToOpenAPI } from '@/common/utils/zod-to-openapi.util';
 import { UserResponseSchema } from '@/users/schemas/user-response.schema';
+import { UsersService } from '@/users/users.service';
 import { type CreateUserDto, CreateUserSchema } from '@repo/shared/schemas/auth';
 import { type LoginDto, LoginSchema } from '@repo/shared/schemas/auth';
+import { UserInfoResponseDto } from '@repo/shared/types/user';
 
 import { AuthService } from './auth.service';
 import { JwtRefreshAuthGuard } from './guards/jwt-refresh-auth.guard';
@@ -32,7 +34,10 @@ import type { Response } from 'express';
 
 @Controller('/api/auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private userService: UsersService,
+  ) {}
 
   // 회원가입 API
   @Post('register')
@@ -123,6 +128,7 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
   ) {
     const { accessToken, refreshToken } = await this.authService.login(req.user);
+    const user: UserInfoResponseDto = await this.userService.getMyProfile(req.user.id);
 
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
@@ -134,6 +140,7 @@ export class AuthController {
 
     return {
       accessToken,
+      user,
     };
   }
 

--- a/apps/fe/src/routes/_public/login.tsx
+++ b/apps/fe/src/routes/_public/login.tsx
@@ -1,14 +1,16 @@
 import { useForm } from 'react-hook-form';
 
-import { loginUser } from '@/apis/auth-api';
+import { loginUser, logoutUser } from '@/apis/auth-api';
+import { getUserInfoApi } from '@/apis/user-api';
 import { AuthHeader } from '@/features/auth/components/AuthHeader';
 import { AuthLayout } from '@/features/auth/components/AuthLayout';
 import { FormInput } from '@/features/auth/components/FormInput';
 import { useAuthStore } from '@/lib/stores/user-auth-store';
+import { useUserStore } from '@/lib/stores/user-store';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { type LoginDto, LoginSchema } from '@repo/shared/schemas/auth';
 import type { BackendErrorResponse } from '@repo/shared/types/error';
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Link, createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
 import { isAxiosError } from 'axios';
 import { Loader2 } from 'lucide-react';
@@ -16,7 +18,8 @@ import { Loader2 } from 'lucide-react';
 const LoginPage = () => {
   const navigate = useNavigate();
 
-  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const authStore = useAuthStore.getState();
+  const userStore = useUserStore.getState();
 
   const {
     register,
@@ -29,14 +32,11 @@ const LoginPage = () => {
   });
 
   const onSubmit = async (data: LoginDto) => {
+    let accessToken: string;
     try {
-      const { accessToken } = await loginUser(data);
-
+      const response = await loginUser(data);
+      accessToken = response.accessToken;
       // 스토어에 토큰 저장
-      setAccessToken(accessToken);
-
-      // 메인 페이지로 이동
-      await navigate({ to: '/', replace: true });
     } catch (error) {
       if (isAxiosError<BackendErrorResponse>(error) && error.response) {
         const { status } = error.response;
@@ -55,6 +55,24 @@ const LoginPage = () => {
         // 네트워크 에러 등
         alert('서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
       }
+      return;
+    }
+    authStore.setAccessToken(accessToken);
+
+    try {
+      const userInfo = await getUserInfoApi();
+
+      userStore.setUserInfo(userInfo);
+      await navigate({ to: '/', replace: true });
+    } catch (error) {
+      try {
+        await logoutUser();
+      } catch (error) {}
+
+      authStore.clearAuth();
+      userStore.clearUserInfo();
+
+      throw redirect({ to: '/login' });
     }
   };
   return (

--- a/apps/fe/src/routes/_public/login.tsx
+++ b/apps/fe/src/routes/_public/login.tsx
@@ -10,10 +10,10 @@ import { useUserStore } from '@/lib/stores/user-store';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { type LoginDto, LoginSchema } from '@repo/shared/schemas/auth';
 import type { BackendErrorResponse } from '@repo/shared/types/error';
-import { Link, createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
 import { isAxiosError } from 'axios';
-import { Loader2 } from 'lucide-react';
+import { AlertCircle, Loader2 } from 'lucide-react';
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -49,11 +49,17 @@ const LoginPage = () => {
           });
         } else {
           // 500 등 기타 서버 에러
-          alert('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+          setError('root', {
+            type: 'server',
+            message: '로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+          });
         }
       } else {
         // 네트워크 에러 등
-        alert('서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+        setError('root', {
+          type: 'network',
+          message: '서버와 연결할 수 없습니다. 네트워크 상태를 확인해주세요.',
+        });
       }
       return;
     }
@@ -72,7 +78,10 @@ const LoginPage = () => {
       authStore.clearAuth();
       userStore.clearUserInfo();
 
-      throw redirect({ to: '/login' });
+      setError('root', {
+        type: 'network',
+        message: '회원 정보를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.',
+      });
     }
   };
   return (
@@ -117,6 +126,13 @@ const LoginPage = () => {
             '로그인'
           )}
         </button>
+
+        {errors.root && (
+          <div className="animate-in fade-in slide-in-from-top-1 flex items-center gap-2 rounded-md bg-red-50 p-3 text-sm text-alert">
+            <AlertCircle size={16} className="shrink-0" />
+            <span>{errors.root.message}</span>
+          </div>
+        )}
 
         {/* Note: 현재는 소셜 로그인 미구현이라 주석처리 해둠. */}
         {/* <div className="relative mt-6">

--- a/apps/fe/src/routes/_public/login.tsx
+++ b/apps/fe/src/routes/_public/login.tsx
@@ -1,7 +1,6 @@
 import { useForm } from 'react-hook-form';
 
-import { loginUser, logoutUser } from '@/apis/auth-api';
-import { getUserInfoApi } from '@/apis/user-api';
+import { loginUser } from '@/apis/auth-api';
 import { AuthHeader } from '@/features/auth/components/AuthHeader';
 import { AuthLayout } from '@/features/auth/components/AuthLayout';
 import { FormInput } from '@/features/auth/components/FormInput';
@@ -32,10 +31,16 @@ const LoginPage = () => {
   });
 
   const onSubmit = async (data: LoginDto) => {
-    let accessToken: string;
     try {
       const response = await loginUser(data);
-      accessToken = response.accessToken;
+      const accessToken = response.accessToken;
+      const userInfo = response.user;
+
+      authStore.setAccessToken(accessToken);
+      userStore.setUserInfo(userInfo);
+
+      navigate({ to: '/', replace: true });
+
       // 스토어에 토큰 저장
     } catch (error) {
       if (isAxiosError<BackendErrorResponse>(error) && error.response) {
@@ -62,26 +67,6 @@ const LoginPage = () => {
         });
       }
       return;
-    }
-    authStore.setAccessToken(accessToken);
-
-    try {
-      const userInfo = await getUserInfoApi();
-
-      userStore.setUserInfo(userInfo);
-      await navigate({ to: '/', replace: true });
-    } catch (error) {
-      try {
-        await logoutUser();
-      } catch (error) {}
-
-      authStore.clearAuth();
-      userStore.clearUserInfo();
-
-      setError('root', {
-        type: 'network',
-        message: '회원 정보를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.',
-      });
     }
   };
   return (

--- a/apps/fe/src/routes/_public/register.tsx
+++ b/apps/fe/src/routes/_public/register.tsx
@@ -11,7 +11,7 @@ import { type BackendErrorResponse } from '@repo/shared/types/error';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
 import { isAxiosError } from 'axios';
-import { Check, Loader2 } from 'lucide-react';
+import { AlertCircle, Check, Loader2 } from 'lucide-react';
 
 const RegisterPage = () => {
   const navigate = useNavigate();
@@ -52,12 +52,13 @@ const RegisterPage = () => {
             clearErrors('nickname');
           }
         } catch (error) {
-          // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
-          console.error('닉네임 중복 확인 시스템 에러', error);
-          alert('닉네임 확인 중 오류가 발생했습니다.');
+          setError('nickname', {
+            type: 'manual',
+            message: '닉네임 확인 중 오류가 발생했습니다.',
+          });
         }
       }
-    }, 1000);
+    }, 500);
 
     return () => clearTimeout(timer);
   }, [nicknameValue, trigger, setError, clearErrors]);
@@ -83,9 +84,10 @@ const RegisterPage = () => {
         setEmailChecked(true);
       }
     } catch (error) {
-      console.error('이메일 중복 확인 시스템 에러', error);
-      // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
-      alert('이메일 확인 중 오류가 발생했습니다.');
+      setError('email', {
+        type: 'manual',
+        message: '이메일 확인 중 오류가 발생했습니다.',
+      });
     }
   };
 
@@ -130,12 +132,16 @@ const RegisterPage = () => {
             });
           });
         } else {
-          // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
-          alert(errorData.message || '회원가입 중 오류가 발생했습니다.');
+          setError('root', {
+            type: 'server',
+            message: '회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+          });
         }
       } else {
-        // todo: 추후에 토스트 메시지 컴포넌트 구현한 후 alert에서 리팩토링 예정
-        alert('서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+        setError('root', {
+          type: 'network',
+          message: '서버와 연결할 수 없습니다. 네트워크 상태를 확인해주세요.',
+        });
       }
     }
   };
@@ -217,6 +223,12 @@ const RegisterPage = () => {
             '가입하기'
           )}
         </button>
+        {errors.root && (
+          <div className="animate-in fade-in slide-in-from-top-1 flex items-center gap-2 rounded-md bg-red-50 p-3 text-sm text-red-600">
+            <AlertCircle size={16} className="shrink-0" />
+            <span>{errors.root.message}</span>
+          </div>
+        )}
       </form>
 
       <div className="mt-8 text-center text-sm text-dark-gray">

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -32,6 +32,7 @@ export type UserInfoResponseDto = {
 
 export type AuthResponseDto = {
   accessToken: string;
+  user: UserInfoResponseDto;
 };
 
 export type RegisterResponseDto = {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #178 

<br/>

## 🔍 작업 내용

### 1. 로그인 후 사용자 정보 조회 요청 로직 추가
로그인에 성공한 후에 `getUserInfoApi()` 함수를 통해 사용자 정보 조회 API를 호출합니다.
성공적으로 응답을 받았으면 전역 사용자 정보 상태를 업데이트 하도록 구현했습니다.

만약에 로그인 요청에는 성공했는데, 사용자 정보 조회 요청이 실패했을 경우에는 로그아웃을 요청하여 다시 로그인을 시도하게 유도하였습니다.

### 2. 로그인/회원가입 서버에서 에러 발생 시 
alert 대신 `react-hook-form` 의 `setError`를 활용하여 UI상에 에러 메시지를 띄우도록 수정

<br/>

## 📷 스크린샷


https://github.com/user-attachments/assets/7faaed7d-2ef2-4355-9718-f394b3dfff49



<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `3분`
> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
로그인 API의 응답 DTO를 수정하여서 로그인 시에 액세스 토큰 + 유저 정보 이렇게 수정하는 것도 고려했으나

auth라는 도메인의 책임은 사용자 인증의 역할만 수행하고, 사용자 정보 조회라는 책임은 users 도메인에서 담당하도록 하는게 적절할 것 같고, 리소스 측면에서도 이런 구현 방식이 restful 하다고 판단하

`/login` -> `/users/me` 이런 순서로 요청하도록 구현하였습니다.

<br/>

## 📄 추가 전달 사항
문제 해결과정은 wiki에 작성!! 토의를 하고 싶다면 discussion으로!

- 공유한 내용이나 반영된 내용은 wiki에 이어서 작성(사고나 작업의 변화를 보기 위해 기존의 내용 수정X)
