### PR TITLE
Refactor/#179 초기화시 비로그인 사용자의 불필요한 refresh 요청 방지

### DIFF
--- a/apps/be/src/auth/auth.controller.spec.ts
+++ b/apps/be/src/auth/auth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { ActiveUser } from '@/common/decorators/active-user.decorator';
+import { UsersService } from '@/users/users.service';
 import { CreateUserDto, LoginDto } from '@repo/shared/schemas/auth';
 
 import { AuthController } from './auth.controller';
@@ -13,6 +14,11 @@ const mockAuthService = {
   login: jest.fn(),
   rotateRefreshToken: jest.fn(),
   logout: jest.fn(),
+};
+
+const mockUsersService = {
+  checkDuplicate: jest.fn(),
+  getMyProfile: jest.fn(),
 };
 
 // Mock Response 객체 정의 (Express Response)
@@ -34,6 +40,10 @@ describe('AuthController', () => {
         {
           provide: AuthService,
           useValue: mockAuthService,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
         },
       ],
     }).compile();
@@ -120,6 +130,15 @@ describe('AuthController', () => {
         }),
       );
 
+      expect(res.cookie).toHaveBeenCalledWith(
+        'isLoggedIn',
+        'true',
+        expect.objectContaining({
+          httpOnly: false, // 클라이언트 접근 허용
+          path: '/',
+        }),
+      );
+
       // 3. 반환값에 AccessToken이 포함되어 있는지 확인
       expect(result).toEqual({ accessToken: tokens.accessToken });
     });
@@ -157,6 +176,13 @@ describe('AuthController', () => {
         newTokens.refreshToken,
         expect.anything(),
       );
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        'isLoggedIn',
+        'true',
+        expect.objectContaining({ httpOnly: false }),
+      );
+
       expect(result).toEqual({ accessToken: newTokens.accessToken });
     });
   });
@@ -181,6 +207,14 @@ describe('AuthController', () => {
         expect.objectContaining({
           path: '/',
           httpOnly: true,
+        }),
+      );
+
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        'isLoggedIn',
+        expect.objectContaining({
+          path: '/',
+          httpOnly: false, // 삭제 시에도 옵션을 맞춰주는지 확인
         }),
       );
     });

--- a/apps/be/src/auth/auth.controller.ts
+++ b/apps/be/src/auth/auth.controller.ts
@@ -138,6 +138,14 @@ export class AuthController {
       maxAge: 14 * 24 * 60 * 60 * 1000,
     });
 
+    res.cookie('isLoggedIn', 'true', {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 14 * 24 * 60 * 60 * 1000, // 리프레시 토큰 수명과 동일하게 설정
+    });
+
     return {
       accessToken,
       user,
@@ -192,6 +200,14 @@ export class AuthController {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
+    res.cookie('isLoggedIn', 'true', {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+
     return { accessToken };
   }
 
@@ -231,12 +247,16 @@ export class AuthController {
     await this.authService.logout(user.id);
 
     // 클라이언트 쿠키 삭제
-    res.clearCookie('refreshToken', {
+    const cookieOption = {
       path: '/',
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-    });
+      sameSite: 'lax' as const,
+    };
+
+    res.clearCookie('refreshToken', cookieOption);
+
+    res.clearCookie('isLoggedIn', { ...cookieOption, httpOnly: false });
 
     return { message: '성공적으로 로그아웃 되었습니다.' };
   }

--- a/apps/fe/src/apis/http.ts
+++ b/apps/fe/src/apis/http.ts
@@ -73,6 +73,8 @@ const handleAuthError = () => {
   useAuthStore.getState().clearAuth();
   useUserStore.getState().clearUserInfo();
 
+  removeIsLoggedInCookie();
+
   const currentPath = window.location.pathname;
   const publicPaths = ['/learning', '/mypage', '/ranking', '/battle'];
 
@@ -80,5 +82,9 @@ const handleAuthError = () => {
   if (publicPaths.includes(currentPath)) {
     window.location.href = '/login';
   }
+};
+
+const removeIsLoggedInCookie = () => {
+  document.cookie = 'isLoggedIn=; path=/; max-age=0;';
 };
 export default axiosInstance;

--- a/apps/fe/src/lib/stores/user-auth-store.ts
+++ b/apps/fe/src/lib/stores/user-auth-store.ts
@@ -6,11 +6,13 @@ type AuthState = {
   accessToken: string | null;
   isAuthenticated: boolean;
   isInitializing: boolean;
+  isTermsAgreed: boolean;
 
   // Actions
   setAccessToken: (token: string | null) => void;
   finishInitializing: () => void;
   clearAuth: () => void; // 로그아웃 시 호출
+  setTermsAgreed: (agreed: boolean) => void;
 };
 
 export const useAuthStore = create<AuthState>()(
@@ -19,6 +21,7 @@ export const useAuthStore = create<AuthState>()(
       accessToken: null,
       isAuthenticated: false,
       isInitializing: true,
+      isTermsAgreed: false,
 
       setAccessToken: (token) =>
         set({ accessToken: token, isAuthenticated: !!token }, false, 'auth/setAccessToken'),
@@ -26,6 +29,7 @@ export const useAuthStore = create<AuthState>()(
       finishInitializing: () => set({ isInitializing: false }, false, 'auth/finishInitializing'),
 
       clearAuth: () => set({ accessToken: null, isAuthenticated: false }, false, 'auth/clearAuth'),
+      setTermsAgreed: (agreed) => set({ isTermsAgreed: agreed }, false, 'auth/setTermsAgreed'),
     }),
     { name: 'AuthStore' },
   ),

--- a/apps/fe/src/routes/__root.tsx
+++ b/apps/fe/src/routes/__root.tsx
@@ -51,6 +51,16 @@ export const Route = createRootRoute({
 
     if (!authStore.isInitializing) return;
 
+    const hasAuthCookie = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith('isLoggedIn='))
+      ?.split('=')[1];
+
+    if (!hasAuthCookie) {
+      authStore.finishInitializing();
+      return;
+    }
+
     try {
       // 인증 갱신 API 호출 (Store 외부에서 수행)
       const { accessToken } = await refreshAccessTokenApi();

--- a/apps/fe/src/routes/_public/agreement.tsx
+++ b/apps/fe/src/routes/_public/agreement.tsx
@@ -19,6 +19,7 @@ type AgreementForm = {
 
 const AgreementPage = () => {
   const navigate = useNavigate();
+  const setTermsAgreed = useAuthStore((state) => state.setTermsAgreed);
 
   const { register, watch, setValue, handleSubmit } = useForm<AgreementForm>({
     mode: 'onChange',
@@ -49,6 +50,7 @@ const AgreementPage = () => {
   };
 
   const onSubmit = () => {
+    setTermsAgreed(true);
     navigate({ to: '/register' });
   };
 

--- a/apps/fe/src/routes/_public/agreement.tsx
+++ b/apps/fe/src/routes/_public/agreement.tsx
@@ -5,8 +5,9 @@ import { PRIVACY_POLICY, SERVICE_TERMS } from '@/constants/terms';
 import { AuthHeader } from '@/features/auth/components/AuthHeader';
 import { AuthLayout } from '@/features/auth/components/AuthLayout';
 import { TermsModal } from '@/features/auth/components/TermsModal';
+import { useAuthStore } from '@/lib/stores/user-auth-store';
 import { cn } from '@/lib/utils';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
 import { Check, ChevronRight } from 'lucide-react';
 
@@ -152,5 +153,10 @@ const AgreementPage = () => {
 };
 
 export const Route = createFileRoute('/_public/agreement')({
+  beforeLoad: () => {
+    if (useAuthStore.getState().isAuthenticated) {
+      throw redirect({ to: '/', replace: true });
+    }
+  },
   component: AgreementPage,
 });

--- a/apps/fe/src/routes/_public/login.tsx
+++ b/apps/fe/src/routes/_public/login.tsx
@@ -9,7 +9,7 @@ import { useUserStore } from '@/lib/stores/user-store';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { type LoginDto, LoginSchema } from '@repo/shared/schemas/auth';
 import type { BackendErrorResponse } from '@repo/shared/types/error';
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Link, createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
 import { isAxiosError } from 'axios';
 import { AlertCircle, Loader2 } from 'lucide-react';
@@ -154,5 +154,10 @@ const LoginPage = () => {
 };
 
 export const Route = createFileRoute('/_public/login')({
+  beforeLoad: () => {
+    if (useAuthStore.getState().isAuthenticated) {
+      throw redirect({ to: '/', replace: true });
+    }
+  },
   component: LoginPage,
 });

--- a/apps/fe/src/routes/_public/register.tsx
+++ b/apps/fe/src/routes/_public/register.tsx
@@ -5,10 +5,11 @@ import { checkEmailDuplicate, checkNicknameDuplicate, registerUser } from '@/api
 import { AuthHeader } from '@/features/auth/components/AuthHeader';
 import { AuthLayout } from '@/features/auth/components/AuthLayout';
 import { FormInput } from '@/features/auth/components/FormInput';
+import { useAuthStore } from '@/lib/stores/user-auth-store';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { type RegisterFormDto, RegisterFormSchema } from '@repo/shared/schemas/auth';
 import { type BackendErrorResponse } from '@repo/shared/types/error';
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Link, createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
 import { isAxiosError } from 'axios';
 import { AlertCircle, Check, Loader2 } from 'lucide-react';
@@ -242,5 +243,10 @@ const RegisterPage = () => {
 };
 
 export const Route = createFileRoute('/_public/register')({
+  beforeLoad: () => {
+    if (useAuthStore.getState().isAuthenticated) {
+      throw redirect({ to: '/', replace: true });
+    }
+  },
   component: RegisterPage,
 });

--- a/apps/fe/src/routes/_public/register.tsx
+++ b/apps/fe/src/routes/_public/register.tsx
@@ -247,6 +247,10 @@ export const Route = createFileRoute('/_public/register')({
     if (useAuthStore.getState().isAuthenticated) {
       throw redirect({ to: '/', replace: true });
     }
+
+    if (!useAuthStore.getState().isTermsAgreed) {
+      throw redirect({ to: '/agreement', replace: true });
+    }
   },
   component: RegisterPage,
 });


### PR DESCRIPTION
## 🔗 관련 이슈

- close #179 

<br/>

## 🔍 작업 내용

### 1. BE: isLoggedIn 쿠키 발급 및 삭제 로직 추가

- 로그인/토큰 갱신 시: refresh 토큰(HttpOnly)과 별개로, 클라이언트에서 로그인 여부를 판별할 수 있는 isLoggedIn 쿠키(Non-HttpOnly)를 함께 발급하도록 수정했습니다.

- 로그아웃 시: refresh 토큰과 함께 isLoggedIn 쿠키도 삭제되도록 처리했습니다.

### 2. FE: 앱 초기화(__root) 시 조건부 Refresh 호출

- 기존: 인증 여부와 상관없이 무조건 refresh API를 호출.

- 변경: document.cookie를 통해 isLoggedIn 플래그가 존재할 때만 API를 호출하도록 변경하여 Guest 유저의 불필요한 API 요청을 차단했습니다.

### 3. FE: 인증 에러 핸들링 강화
- 401 에러(인증 만료) 발생 시, 클라이언트의 isLoggedIn 쿠키를 즉시 삭제하여 이후 불필요한 재시도를 방지했습니다.

### 4. auth.controller.spec.ts 단위 테스트 코드 변경사항 반영
로그인 플래그 쿠키 전달에 대한 변경사항을 반영하여 테스트 코드를 수정했습니다.

<br/>

## 📷 스크린샷

<img width="1509" height="60" alt="image" src="https://github.com/user-attachments/assets/ea5be5ba-a354-4e94-8d02-0f1c859c3155" />


<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `3분`
> 리뷰어에게 남기고 싶은 말) 

isLoggedIn 쿠키는 단순히 "로그인 시도 가능 여부"를 판단하는 클라이언트용 플래그일 뿐이며, 실제 보안 인증은 HttpOnly 쿠키인 refreshToken을 통해 이루어집니다.
<br/>

## 📄 추가 전달 사항
문제 해결과정은 wiki에 작성!! 토의를 하고 싶다면 discussion으로!

- 공유한 내용이나 반영된 내용은 wiki에 이어서 작성(사고나 작업의 변화를 보기 위해 기존의 내용 수정X)
