### PR TITLE
Refactor/#188 크레딧 소진 시 학습 세션 시작 차단 로직 추가

### DIFF
--- a/apps/fe/__test__/e2e/learning-setup.spec.ts
+++ b/apps/fe/__test__/e2e/learning-setup.spec.ts
@@ -172,14 +172,13 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
     // 3. 시작 버튼 클릭 시도
     const startButton = page.getByRole('button', { name: '학습 시작하기' });
 
-    await page.route('**/api/learning/sessions', async (route) => {
-      await route.fulfill({
-        status: 409,
-        json: { message: '잔여 크레딧이 부족하여 세션을 진행할 수 없습니다.' },
-      });
-    });
+    // disabled 상태 확인
+    await expect(startButton).toBeDisabled();
 
-    await startButton.click();
-    await expect(page.getByText('잔여 크레딧이 부족하여 세션을 진행할 수 없습니다.')).toBeVisible();
+    // 툴팁 트리거 (강제 hover)
+    await startButton.hover({ force: true });
+
+    // 툴팁 텍스트 확인
+    await expect(page.getByText('크레딧이 부족하여 학습을 시작할 수 없어요')).toBeVisible();
   });
 });

--- a/apps/fe/src/features/learning/components/learning/difficulty-selector.tsx
+++ b/apps/fe/src/features/learning/components/learning/difficulty-selector.tsx
@@ -1,0 +1,63 @@
+import type { QUESTION_DIFFICULTY_CONFIG } from '@/constants/question';
+import type { QuestionDifficulty } from '@repo/shared/constants/learning';
+
+type DifficultySelectorProps = {
+  isVisible: boolean;
+  options: (typeof QUESTION_DIFFICULTY_CONFIG)[keyof typeof QUESTION_DIFFICULTY_CONFIG][];
+  selectedDifficulty: QuestionDifficulty | null;
+  onSelect: (value: QuestionDifficulty) => void;
+};
+
+const DifficultySelector = ({
+  isVisible,
+  options,
+  selectedDifficulty,
+  onSelect,
+}: DifficultySelectorProps) => {
+  return (
+    <section
+      className={`rounded-2xl border border-gray bg-white p-5 shadow-sm transition-all duration-700 ease-in-out md:p-8 ${
+        isVisible
+          ? 'visible translate-y-0 opacity-100'
+          : 'pointer-events-none invisible translate-y-10 opacity-0'
+      }`}
+      aria-hidden={!isVisible}
+    >
+      <h2 className="mb-4 text-lg font-bold md:text-xl">난이도 설정</h2>
+      <ul className="flex w-full rounded-lg bg-gray p-1">
+        {options.map((diff) => {
+          const isSelected = selectedDifficulty === diff.value;
+          return (
+            <li key={diff.value} className="flex-1">
+              <label
+                className={`flex cursor-pointer items-center justify-center rounded-md py-3 text-sm transition-all outline-none focus-within:bg-white active:scale-95 md:py-2 md:active:scale-100 ${
+                  isSelected
+                    ? 'bg-white font-bold text-black shadow-sm'
+                    : 'font-medium text-dark-gray hover:text-black'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="difficulty-level"
+                  value={diff.value}
+                  checked={isSelected}
+                  onChange={() => onSelect(diff.value)}
+                  className="sr-only"
+                />
+                {diff.label}
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="mt-3 flex items-start gap-2 text-xs text-dark-gray md:items-center">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-primary text-[0.625rem] text-primary">
+          i
+        </span>
+        <span>전공자 수준의 심화 질문이 출제됩니다.</span>
+      </div>
+    </section>
+  );
+};
+
+export default DifficultySelector;

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -28,7 +28,7 @@ const LearningHeader = ({
           학습하기
         </Link>
       </div>
-      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
         <div>
           <h1 className="mb-2 text-lg font-bold md:text-3xl">안녕하세요, {nickname}님! 👋</h1>
           <p className="text-sm text-dark-gray md:text-base">

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -37,17 +37,15 @@ const LearningHeader = ({
             남았어요.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-3 self-start md:self-auto">
+        <div className="flex flex-wrap gap-3">
           <Tooltip.Provider delayDuration={200}>
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
-                <div className="cursor-help rounded-full border border-primary/20 bg-primary/5 px-4 py-2 shadow-xs transition-colors hover:bg-primary/10">
-                  <div className="flex items-center gap-2">
-                    <Coins className="h-5 w-5 text-primary" />
-                    <span className="text-sm font-bold text-primary">
-                      {remainingCredit.toLocaleString()} 크레딧
-                    </span>
-                  </div>
+                <div className="flex cursor-help items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-2 shadow-xs transition-colors hover:bg-primary/10">
+                  <Coins className="h-5 w-5 text-primary" />
+                  <span className="text-sm font-bold text-primary">
+                    {remainingCredit.toLocaleString()} 크레딧
+                  </span>
                 </div>
               </Tooltip.Trigger>
               <Tooltip.Portal>
@@ -64,11 +62,9 @@ const LearningHeader = ({
             </Tooltip.Root>
           </Tooltip.Provider>
 
-          <div className="rounded-full border border-gray bg-white px-4 py-2 shadow-xs">
-            <div className="flex items-center gap-2">
-              <Flame className="h-5 w-5 text-orange" />
-              <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
-            </div>
+          <div className="flex items-center gap-2 rounded-full border border-gray bg-white px-4 py-2 shadow-xs">
+            <Flame className="h-5 w-5 text-orange" />
+            <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
           </div>
         </div>
       </div>

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -1,0 +1,66 @@
+import type { UserInfoResponseDto } from '@repo/shared/types/user';
+import { Link } from '@tanstack/react-router';
+
+import { Flame } from 'lucide-react';
+
+type LearningHeaderProps = {
+  nickname: string;
+  studyStats: UserInfoResponseDto['studyStats'];
+  progression: UserInfoResponseDto['progression'];
+  progress: number;
+  calculatedPercent: number;
+};
+
+const LearningHeader = ({
+  nickname,
+  studyStats,
+  progression,
+  progress,
+  calculatedPercent,
+}: LearningHeaderProps) => {
+  return (
+    <header className="space-y-2">
+      <div className="mb-4 text-sm font-bold">
+        <Link to="/learning" className="text-primary">
+          학습하기
+        </Link>
+      </div>
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+        <div>
+          <h1 className="mb-2 text-lg font-bold md:text-3xl">안녕하세요, {nickname}님! 👋</h1>
+          <p className="text-sm text-dark-gray md:text-base">
+            <span className="hidden md:inline">오늘도 CS 지식을 쌓아볼까요?</span> 목표 달성까지
+            <span className="mx-1 font-bold text-primary">{100 - calculatedPercent}%</span>
+            남았어요.
+          </p>
+        </div>
+        <div className="self-start rounded-full border border-gray bg-white px-4 py-2 shadow-sm md:self-auto">
+          <div className="flex items-center gap-2">
+            <Flame className="h-5 w-5 text-orange" />
+            <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
+          </div>
+        </div>
+      </div>
+
+      {/* [모바일 전용] 레벨 프로그레스 바 */}
+      <div className="mt-4 block rounded-xl md:hidden">
+        <div className="mb-2 flex justify-between text-xs font-bold text-dark-gray">
+          <span>
+            {progression?.level} Lv ({progression?.currentXp} XP)
+          </span>
+          <span className="text-gray-400">
+            {progression?.level + 1} Lv ({progression.requiredXpForNextLevel} XP)
+          </span>
+        </div>
+        <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default LearningHeader;

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -1,12 +1,14 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
 import type { UserInfoResponseDto } from '@repo/shared/types/user';
 import { Link } from '@tanstack/react-router';
 
-import { Flame } from 'lucide-react';
+import { Coins, Flame } from 'lucide-react';
 
 type LearningHeaderProps = {
   nickname: string;
   studyStats: UserInfoResponseDto['studyStats'];
   progression: UserInfoResponseDto['progression'];
+  remainingCredit: number;
   progress: number;
   calculatedPercent: number;
 };
@@ -15,6 +17,7 @@ const LearningHeader = ({
   nickname,
   studyStats,
   progression,
+  remainingCredit,
   progress,
   calculatedPercent,
 }: LearningHeaderProps) => {
@@ -34,10 +37,38 @@ const LearningHeader = ({
             남았어요.
           </p>
         </div>
-        <div className="self-start rounded-full border border-gray bg-white px-4 py-2 shadow-sm md:self-auto">
-          <div className="flex items-center gap-2">
-            <Flame className="h-5 w-5 text-orange" />
-            <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
+        <div className="flex flex-wrap items-center gap-3 self-start md:self-auto">
+          <Tooltip.Provider delayDuration={200}>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <div className="cursor-help rounded-full border border-primary/20 bg-primary/5 px-4 py-2 shadow-xs transition-colors hover:bg-primary/10">
+                  <div className="flex items-center gap-2">
+                    <Coins className="h-5 w-5 text-primary" />
+                    <span className="text-sm font-bold text-primary">
+                      {remainingCredit.toLocaleString()} 크레딧
+                    </span>
+                  </div>
+                </div>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  side="bottom"
+                  sideOffset={5}
+                  className="animate-in fade-in-0 zoom-in-95 z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+                >
+                  답변을 제출할 수 있는 횟수가
+                  <span className="font-bold text-primary"> {remainingCredit}회</span> 남았습니다
+                  <Tooltip.Arrow className="fill-white" />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+
+          <div className="rounded-full border border-gray bg-white px-4 py-2 shadow-xs">
+            <div className="flex items-center gap-2">
+              <Flame className="h-5 w-5 text-orange" />
+              <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/fe/src/features/learning/components/learning/learning-stats-section.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-stats-section.tsx
@@ -1,0 +1,85 @@
+import type { UserInfoResponseDto } from '@repo/shared/types/user';
+
+import { TrendingUp } from 'lucide-react';
+
+type LearningStatsSectionProps = {
+  progression: UserInfoResponseDto['progression'];
+  studyStats: UserInfoResponseDto['studyStats'];
+  progress: number;
+  calculatedPercent: number;
+};
+
+const LearningStatsSection = ({
+  progression,
+  studyStats,
+  progress,
+  calculatedPercent,
+}: LearningStatsSectionProps) => {
+  return (
+    <>
+      <section className="hidden grid-cols-1 gap-4 md:grid md:gap-6 lg:grid-cols-3">
+        {/* 경험치 바 카드 */}
+        <div className="rounded-2xl border border-gray bg-white p-5 shadow-sm md:col-span-2 md:p-6">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <div className="rounded-md bg-primary/10 p-1.5">
+                <TrendingUp className="h-5 w-5 text-primary" />
+              </div>
+              <h2 className="text-lg font-bold">현재 레벨 경험치</h2>
+            </div>
+            <span className="text-sm text-dark-gray">
+              다음 레벨: {(progression?.level ?? 0) + 1} Lv
+            </span>
+          </div>
+          <div className="mb-2 flex items-end gap-2">
+            <span className="text-3xl font-extrabold text-black md:text-4xl">
+              {calculatedPercent}%
+            </span>
+            <span className="mb-1 ml-auto text-xs text-dark-gray md:text-sm">
+              {progression?.currentXp} / {progression?.requiredXpForNextLevel} XP
+            </span>
+          </div>
+          <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        {/* 요약 통계 카드 */}
+        <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm md:p-6">
+          <h2 className="mb-4 text-lg font-bold">학습 요약</h2>
+          <div className="flex justify-between px-2 sm:justify-start sm:gap-20 sm:px-0">
+            <div>
+              <p className="mb-1 text-sm text-dark-gray">누적 답변</p>
+              <p className="text-2xl font-bold text-black">{studyStats?.solvedProblemCount}개</p>
+            </div>
+            <div>
+              <p className="mb-1 text-sm text-dark-gray">총 학습 시간</p>
+              <p className="text-2xl font-bold text-primary">
+                {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 모바일 전용 통계 카드 */}
+      <section className="grid grid-cols-2 gap-3 md:hidden">
+        <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
+          <p className="mb-2 text-sm text-dark-gray">누적 답변</p>
+          <p className="text-lg font-bold text-black">{studyStats?.solvedProblemCount}개</p>
+        </div>
+        <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
+          <p className="mb-2 text-sm text-dark-gray">총 학습 시간</p>
+          <p className="text-lg font-bold text-primary">
+            {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
+          </p>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default LearningStatsSection;

--- a/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
+++ b/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
@@ -1,0 +1,88 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+
+import { Mic } from 'lucide-react';
+
+type StartSessionBannerProps = {
+  isVisible: boolean;
+  selectedTopicLabel?: string;
+  selectedDifficultyLabel?: string;
+  isLoading: boolean;
+  isStartDisabled: boolean;
+  isCreditInsufficient: boolean;
+  onStart: () => void;
+};
+
+const StartSessionBanner = ({
+  isVisible,
+  selectedTopicLabel,
+  selectedDifficultyLabel,
+  isLoading,
+  isStartDisabled,
+  isCreditInsufficient,
+  onStart,
+}: StartSessionBannerProps) => {
+  return (
+    <section
+      className={`relative flex transform flex-col items-center justify-between overflow-hidden rounded-2xl bg-black p-6 text-white transition-all duration-700 ease-in-out md:flex-row md:p-8 ${
+        isVisible
+          ? 'visible translate-y-0 opacity-100'
+          : 'pointer-events-none invisible translate-y-10 opacity-0'
+      }`}
+      aria-hidden={!isVisible}
+    >
+      <div className="pointer-events-none absolute top-0 left-0 h-full w-full bg-linear-to-r from-primary/20 to-transparent"></div>
+
+      <div className="z-10 mb-6 w-full md:mb-0 md:w-auto">
+        <span className="mb-2 inline-block rounded-3xl border border-primary/30 bg-primary/30 px-2 py-1 text-xs text-primary">
+          AI Learning
+        </span>
+        <p className="mb-1 text-lg font-bold md:text-xl">오늘의 AI 튜터가 준비되었습니다.</p>
+        <p className="text-sm text-gray">
+          선택하신 <span className="mx-1 font-bold text-primary">{selectedTopicLabel}</span> 주제 /
+          <span className="mx-1 font-bold text-primary">{selectedDifficultyLabel}</span> 난이도
+        </p>
+      </div>
+
+      <Tooltip.Provider delayDuration={200}>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
+              <button
+                onClick={onStart}
+                disabled={isStartDisabled}
+                className={`flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${
+                  isStartDisabled
+                    ? 'cursor-not-allowed bg-dark-gray'
+                    : 'bg-primary hover:bg-primary/80'
+                }`}
+              >
+                {isLoading ? (
+                  <span>질문 생성 중...</span>
+                ) : (
+                  <>
+                    <Mic className="h-5 w-5" />
+                    <span className="text-lg md:text-base">학습 시작하기</span>
+                  </>
+                )}
+              </button>
+            </span>
+          </Tooltip.Trigger>
+          {isCreditInsufficient && (
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="top"
+                sideOffset={8}
+                className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+              >
+                크레딧이 부족하여 학습을 시작할 수 없어요
+                <Tooltip.Arrow className="fill-white" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          )}
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </section>
+  );
+};
+
+export default StartSessionBanner;

--- a/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
+++ b/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
@@ -44,7 +44,7 @@ const StartSessionBanner = ({
       </div>
 
       <Tooltip.Provider delayDuration={200}>
-        <Tooltip.Root>
+        <Tooltip.Root open={isCreditInsufficient ? undefined : false}>
           <Tooltip.Trigger asChild>
             <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
               <button
@@ -67,18 +67,16 @@ const StartSessionBanner = ({
               </button>
             </span>
           </Tooltip.Trigger>
-          {isCreditInsufficient && (
-            <Tooltip.Portal>
-              <Tooltip.Content
-                side="top"
-                sideOffset={8}
-                className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
-              >
-                크레딧이 부족하여 학습을 시작할 수 없어요
-                <Tooltip.Arrow className="fill-white" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          )}
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="top"
+              sideOffset={8}
+              className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+            >
+              크레딧이 부족하여 학습을 시작할 수 없어요
+              <Tooltip.Arrow className="fill-white" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Tooltip.Provider>
     </section>

--- a/apps/fe/src/features/learning/components/learning/topic-selector.tsx
+++ b/apps/fe/src/features/learning/components/learning/topic-selector.tsx
@@ -1,0 +1,56 @@
+import type { QUESTION_CATEGORY_CONFIG } from '@/constants/question';
+import type { QuestionCategory } from '@repo/shared/constants/learning';
+
+import { ListFilter } from 'lucide-react';
+
+type TopicSelectorProps = {
+  options: (typeof QUESTION_CATEGORY_CONFIG)[keyof typeof QUESTION_CATEGORY_CONFIG][];
+  selectedTopic: QuestionCategory | null;
+  onSelect: (id: QuestionCategory) => void;
+};
+
+const TopicSelector = ({ options, selectedTopic, onSelect }: TopicSelectorProps) => {
+  return (
+    <section>
+      <div className="mb-4 flex items-center gap-2 md:mb-6">
+        <ListFilter className="h-5 w-5 text-primary" aria-hidden="true" />
+        <h2 className="text-lg font-bold md:text-xl">학습 주제 선택 (Learning Path)</h2>
+      </div>
+
+      <ul className="scrollbar-hide flex gap-4 overflow-x-auto pb-4 md:grid md:grid-cols-2 md:gap-3 md:overflow-visible lg:grid-cols-4">
+        {options.map((topic) => {
+          const isSelected = selectedTopic === topic.id;
+          return (
+            <li key={topic.id} className="min-w-55 md:min-w-0">
+              <label
+                className={`group block h-full cursor-pointer rounded-xl border-2 p-4 transition-all outline-none focus-within:bg-white active:scale-95 md:active:scale-100 ${
+                  isSelected
+                    ? 'border-primary bg-white shadow-md'
+                    : 'border-transparent bg-transparent hover:border-gray hover:bg-white'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="learning-topic"
+                  value={topic.id}
+                  checked={isSelected}
+                  onChange={() => onSelect(topic.id)}
+                  className="sr-only"
+                />
+                <div
+                  className={`mb-3 transition-colors group-hover:text-primary ${isSelected ? 'text-primary' : 'text-black'}`}
+                >
+                  <topic.Icon className="h-6 w-6" />
+                </div>
+                <p className="mb-1 text-lg font-bold">{topic.label}</p>
+                <p className="text-xs text-dark-gray">{topic.description}</p>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default TopicSelector;

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -59,6 +59,7 @@ const LearningPage = () => {
           nickname={profile.nickname}
           studyStats={studyStats}
           progression={progression}
+          remainingCredit={remainingCredit}
           progress={progress}
           calculatedPercent={calculatedPercent}
         />

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -5,6 +5,7 @@ import { QUESTION_CATEGORY_CONFIG, QUESTION_DIFFICULTY_CONFIG } from '@/constant
 import { useProgressAnimation } from '@/features/learning/lib/hooks/use-progress-animation';
 import useLearningSession from '@/lib/stores/learning-session';
 import { useUserStore } from '@/lib/stores/user-store';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { type QuestionCategory, type QuestionDifficulty } from '@repo/shared/constants/learning';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
@@ -17,7 +18,7 @@ const LearningPage = () => {
 
   const setQuestion = useLearningSession((state) => state.setQuestion);
 
-  const { profile, progression, studyStats } = userInfo;
+  const { profile, progression, studyStats, remainingCredit } = userInfo;
 
   const { progress, calculatedPercent } = useProgressAnimation(
     progression?.currentXp ?? 0,
@@ -31,8 +32,13 @@ const LearningPage = () => {
   const topicOptions = Object.values(QUESTION_CATEGORY_CONFIG);
   const difficultyOptions = Object.values(QUESTION_DIFFICULTY_CONFIG);
 
+  const isCreditInsufficient = remainingCredit <= 0;
+  const isStartDisabled = isLoading || isCreditInsufficient;
+
   const handleStartClick = async () => {
-    if (!selectedTopic || !selectedDifficulty) return;
+    if (!selectedTopic || !selectedDifficulty || isCreditInsufficient) return;
+
+    setIsLoading(true);
     try {
       const data = await startSessionApi(selectedTopic, selectedDifficulty);
       setQuestion(data);
@@ -268,20 +274,44 @@ const LearningPage = () => {
             </p>
           </div>
 
-          <button
-            onClick={handleStartClick}
-            disabled={isLoading}
-            className={`z-10 flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${isLoading ? `cursor-not-allowed bg-gray-600` : `bg-primary hover:bg-primary/80`} `}
-          >
-            {isLoading ? (
-              <span>질문 생성 중...</span>
-            ) : (
-              <>
-                <Mic className="h-5 w-5" />
-                <span className="text-lg md:text-base">학습 시작하기</span>
-              </>
-            )}
-          </button>
+          <Tooltip.Provider delayDuration={200}>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
+                  <button
+                    onClick={handleStartClick}
+                    disabled={isStartDisabled}
+                    className={`flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${
+                      isStartDisabled
+                        ? `cursor-not-allowed bg-dark-gray`
+                        : `bg-primary hover:bg-primary/80`
+                    } `}
+                  >
+                    {isLoading ? (
+                      <span>질문 생성 중...</span>
+                    ) : (
+                      <>
+                        <Mic className="h-5 w-5" />
+                        <span className="text-lg md:text-base">학습 시작하기</span>
+                      </>
+                    )}
+                  </button>
+                </span>
+              </Tooltip.Trigger>
+              {isCreditInsufficient && (
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    side="top"
+                    sideOffset={8}
+                    className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+                  >
+                    크레딧이 부족하여 학습을 시작할 수 없어요
+                    <Tooltip.Arrow className="fill-white" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              )}
+            </Tooltip.Root>
+          </Tooltip.Provider>
         </section>
       </div>
     </div>

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -2,32 +2,32 @@ import { useState } from 'react';
 
 import { startSessionApi } from '@/apis/learning-api';
 import { QUESTION_CATEGORY_CONFIG, QUESTION_DIFFICULTY_CONFIG } from '@/constants/question';
+import DifficultySelector from '@/features/learning/components/learning/difficulty-selector';
+import LearningHeader from '@/features/learning/components/learning/learning-header';
+import LearningStatsSection from '@/features/learning/components/learning/learning-stats-section';
+import StartSessionBanner from '@/features/learning/components/learning/start-sesssion-banner';
+import TopicSelector from '@/features/learning/components/learning/topic-selector';
 import { useProgressAnimation } from '@/features/learning/lib/hooks/use-progress-animation';
 import useLearningSession from '@/lib/stores/learning-session';
 import { useUserStore } from '@/lib/stores/user-store';
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { type QuestionCategory, type QuestionDifficulty } from '@repo/shared/constants/learning';
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
-
-import { Flame, ListFilter, Mic, TrendingUp } from 'lucide-react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
 const LearningPage = () => {
   const userInfo = useUserStore((state) => state.userInfo)!;
-  const [isLoading, setIsLoading] = useState(false);
+  const setQuestion = useLearningSession((state) => state.setQuestion);
   const navigate = useNavigate();
 
-  const setQuestion = useLearningSession((state) => state.setQuestion);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedTopic, setSelectedTopic] = useState<QuestionCategory | null>(null);
+  const [selectedDifficulty, setSelectedDifficulty] = useState<QuestionDifficulty | null>(null);
 
   const { profile, progression, studyStats, remainingCredit } = userInfo;
-
   const { progress, calculatedPercent } = useProgressAnimation(
     progression?.currentXp ?? 0,
     progression?.requiredXpForNextLevel ?? 100,
     100,
   );
-
-  const [selectedTopic, setSelectedTopic] = useState<QuestionCategory | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<QuestionDifficulty | null>(null);
 
   const topicOptions = Object.values(QUESTION_CATEGORY_CONFIG);
   const difficultyOptions = Object.values(QUESTION_DIFFICULTY_CONFIG);
@@ -55,264 +55,49 @@ const LearningPage = () => {
     <div className="flex min-h-screen justify-center bg-pale-blue p-8">
       <div className="w-full max-w-5xl space-y-6 md:space-y-8">
         {/* 상단 헤더 */}
-        <header className="space-y-2">
-          <div className="mb-4 text-sm font-bold">
-            <Link to="/learning" className="text-primary">
-              학습하기
-            </Link>
-          </div>
-          <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
-            <div>
-              <h1 className="mb-2 text-lg font-bold md:text-3xl">
-                안녕하세요, {profile.nickname}
-                님! 👋
-              </h1>
-              <p className="text-sm text-dark-gray md:text-base">
-                <span className="hidden md:inline">오늘도 CS 지식을 쌓아볼까요?</span> 목표 달성까지
-                <span className="mx-1 font-bold text-primary">{100 - calculatedPercent}%</span>
-                남았어요.
-              </p>
-            </div>
-            <div className="self-start rounded-full border border-gray bg-white px-4 py-2 shadow-sm md:self-auto">
-              <div className="flex items-center gap-2">
-                <Flame className="h-5 w-5 text-orange" />
-                <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
-              </div>
-            </div>
-          </div>
-          {/* [모바일 전용] 레벨 프로그레스 바 */}
-          <div className="mt-4 block rounded-xl md:hidden">
-            <div className="mb-2 flex justify-between text-xs font-bold text-dark-gray">
-              <span>
-                {progression?.level} Lv ({progression?.currentXp} XP)
-              </span>
-              <span className="text-gray-400">
-                {progression?.level + 1} Lv ({progression.requiredXpForNextLevel} XP)
-              </span>
-            </div>
-            <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-          </div>
-        </header>
+        <LearningHeader
+          nickname={profile.nickname}
+          studyStats={studyStats}
+          progression={progression}
+          progress={progress}
+          calculatedPercent={calculatedPercent}
+        />
 
         {/* 사용자 스탯 */}
-        <section className="hidden grid-cols-1 gap-4 md:grid md:gap-6 lg:grid-cols-3">
-          {/* 경험치 바 카드 */}
-          <div className="rounded-2xl border border-gray bg-white p-5 shadow-sm md:col-span-2 md:p-6">
-            <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <div className="rounded-md bg-primary/10 p-1.5">
-                  <TrendingUp className="h-5 w-5 text-primary" />
-                </div>
-                <h2 className="text-lg font-bold">현재 레벨 경험치</h2>
-              </div>
-              <span className="text-sm text-dark-gray">
-                다음 레벨: {(progression?.level ?? 0) + 1} Lv
-              </span>
-            </div>
-
-            <div className="mb-2 flex items-end gap-2">
-              <span className="text-3xl font-extrabold text-black md:text-4xl">
-                {calculatedPercent}%
-              </span>
-              <span className="mb-1 ml-auto text-xs text-dark-gray md:text-sm">
-                {progression?.currentXp} / {progression?.requiredXpForNextLevel} XP
-              </span>
-            </div>
-            <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
-                style={{
-                  width: `${progress}%`,
-                }}
-              ></div>
-            </div>
-          </div>
-
-          {/* 요약 통계 카드 */}
-          <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm md:p-6">
-            <h2 className="mb-4 text-lg font-bold">학습 요약</h2>
-            <div className="flex justify-between px-2 sm:justify-start sm:gap-20 sm:px-0">
-              <div>
-                <p className="mb-1 text-sm text-dark-gray">누적 답변</p>
-                <p className="text-2xl font-bold text-black">{studyStats?.solvedProblemCount}개</p>
-              </div>
-              <div>
-                <p className="mb-1 text-sm text-dark-gray">총 학습 시간</p>
-                <p className="text-2xl font-bold text-primary">
-                  {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* 모바일 전용 통계 카드 */}
-        <section className="grid grid-cols-2 gap-3 md:hidden">
-          <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
-            <p className="mb-2 text-sm text-dark-gray">누적 답변</p>
-            <p className="text-lg font-bold text-black">{studyStats?.solvedProblemCount}개</p>
-          </div>
-          <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
-            <p className="mb-2 text-sm text-dark-gray">총 학습 시간</p>
-            <p className="text-lg font-bold text-primary">
-              {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
-            </p>
-          </div>
-        </section>
+        <LearningStatsSection
+          progression={progression}
+          studyStats={studyStats}
+          progress={progress}
+          calculatedPercent={calculatedPercent}
+        />
 
         {/* 주제 선택 */}
-        <section>
-          <div className="mb-4 flex items-center gap-2 md:mb-6">
-            <ListFilter className="h-5 w-5 text-primary" aria-hidden="true" />
-            <h2 className="text-lg font-bold md:text-xl">학습 주제 선택 (Learning Path)</h2>
-          </div>
-
-          <ul className="scrollbar-hide flex gap-4 overflow-x-auto pb-4 md:grid md:grid-cols-2 md:gap-3 md:overflow-visible lg:grid-cols-4">
-            {topicOptions.map((topic) => {
-              const isSelected = selectedTopic === topic.id;
-              return (
-                <li key={topic.id} className="min-w-55 md:min-w-0">
-                  <label
-                    className={`group block h-full cursor-pointer rounded-xl border-2 p-4 transition-all outline-none focus-within:bg-white active:scale-95 md:active:scale-100 ${
-                      isSelected
-                        ? 'border-primary bg-white shadow-md'
-                        : 'border-transparent bg-transparent hover:border-gray hover:bg-white'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="learning-topic"
-                      value={topic.id}
-                      checked={isSelected}
-                      onChange={() => setSelectedTopic(topic.id)}
-                      className="sr-only"
-                    />
-
-                    <div
-                      className={`mb-3 transition-colors group-hover:text-primary ${isSelected ? `text-primary` : `text-black`}`}
-                    >
-                      <topic.Icon className="h-6 w-6" />
-                    </div>
-                    <p className="mb-1 text-lg font-bold">{topic.label}</p>
-                    <p className="text-xs text-dark-gray">{topic.description}</p>
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
+        <TopicSelector
+          options={topicOptions}
+          selectedTopic={selectedTopic}
+          onSelect={setSelectedTopic}
+        />
 
         {/* 난이도 설정 */}
-        <section
-          className={`rounded-2xl border border-gray bg-white p-5 shadow-sm transition-all duration-700 ease-in-out md:p-8 ${selectedTopic !== null ? `visible translate-y-0 opacity-100` : `pointer-events-none invisible translate-y-10 opacity-0`}`}
-          aria-hidden={selectedTopic === null}
-        >
-          <h2 className="mb-4 text-lg font-bold md:text-xl">난이도 설정</h2>
-
-          <ul className="flex w-full rounded-lg bg-gray p-1">
-            {difficultyOptions.map((diff) => {
-              const isSelected = selectedDifficulty === diff.value;
-              return (
-                <li key={diff.value} className="flex-1">
-                  <label
-                    className={`flex cursor-pointer items-center justify-center rounded-md py-3 text-sm transition-all outline-none focus-within:bg-white active:scale-95 md:py-2 md:active:scale-100 ${
-                      isSelected
-                        ? 'bg-white font-bold text-black shadow-sm'
-                        : 'font-medium text-dark-gray hover:text-black'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="difficulty-level"
-                      value={diff.value}
-                      checked={isSelected}
-                      onChange={() => setSelectedDifficulty(diff.value)}
-                      className="sr-only"
-                    />
-                    {diff.label}
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
-
-          <div className="mt-3 flex items-start gap-2 text-xs text-dark-gray md:items-center">
-            <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-primary text-[0.625rem] text-primary">
-              i
-            </span>
-            <span>전공자 수준의 심화 질문이 출제됩니다.</span>
-          </div>
-        </section>
+        <DifficultySelector
+          isVisible={selectedTopic !== null}
+          options={difficultyOptions}
+          selectedDifficulty={selectedDifficulty}
+          onSelect={setSelectedDifficulty}
+        />
 
         {/* 학습 시작 버튼 섹션 */}
-        <section
-          className={`relative flex transform flex-col items-center justify-between overflow-hidden rounded-2xl bg-black p-6 text-white transition-all duration-700 ease-in-out md:flex-row md:p-8 ${selectedTopic !== null && selectedDifficulty !== null ? `visible translate-y-0 opacity-100` : `pointer-events-none invisible translate-y-10 opacity-0`}`}
-          aria-hidden={!selectedTopic || !selectedDifficulty}
-        >
-          <div className="pointer-events-none absolute top-0 left-0 h-full w-full bg-linear-to-r from-primary/20 to-transparent"></div>
-
-          <div className="z-10 mb-6 w-full md:mb-0 md:w-auto">
-            <span className="mb-2 inline-block rounded-3xl border border-primary/30 bg-primary/30 px-2 py-1 text-xs text-primary">
-              AI Learning
-            </span>
-            <p className="mb-1 text-lg font-bold md:text-xl">오늘의 AI 튜터가 준비되었습니다.</p>
-            <p className="text-sm text-gray">
-              선택하신
-              <span className="mx-1 font-bold text-primary">
-                {topicOptions.find((t) => t.id === selectedTopic)?.label}
-              </span>
-              주제 /
-              <span className="mx-1 font-bold text-primary">
-                {difficultyOptions.find((d) => d.value === selectedDifficulty)?.label}
-              </span>
-              난이도
-            </p>
-          </div>
-
-          <Tooltip.Provider delayDuration={200}>
-            <Tooltip.Root>
-              <Tooltip.Trigger asChild>
-                <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
-                  <button
-                    onClick={handleStartClick}
-                    disabled={isStartDisabled}
-                    className={`flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${
-                      isStartDisabled
-                        ? `cursor-not-allowed bg-dark-gray`
-                        : `bg-primary hover:bg-primary/80`
-                    } `}
-                  >
-                    {isLoading ? (
-                      <span>질문 생성 중...</span>
-                    ) : (
-                      <>
-                        <Mic className="h-5 w-5" />
-                        <span className="text-lg md:text-base">학습 시작하기</span>
-                      </>
-                    )}
-                  </button>
-                </span>
-              </Tooltip.Trigger>
-              {isCreditInsufficient && (
-                <Tooltip.Portal>
-                  <Tooltip.Content
-                    side="top"
-                    sideOffset={8}
-                    className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
-                  >
-                    크레딧이 부족하여 학습을 시작할 수 없어요
-                    <Tooltip.Arrow className="fill-white" />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              )}
-            </Tooltip.Root>
-          </Tooltip.Provider>
-        </section>
+        <StartSessionBanner
+          isVisible={selectedTopic !== null && selectedDifficulty !== null}
+          selectedTopicLabel={topicOptions.find((t) => t.id === selectedTopic)?.label}
+          selectedDifficultyLabel={
+            difficultyOptions.find((d) => d.value === selectedDifficulty)?.label
+          }
+          isLoading={isLoading}
+          isStartDisabled={isStartDisabled}
+          isCreditInsufficient={isCreditInsufficient}
+          onStart={handleStartClick}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔗 관련 이슈

- close #188 

<br/>

## 🔍 작업 내용

### 1. Frontend: learning 페이지 리팩토링 및 크레딧 부족 시 세션 시작 차단 로직 추가
- LearningPage 내부의 복잡한 UI 섹션들을 별도 컴포넌트로 분리 (LearningHeader, TopicSelector, DifficultySelector, StartSessionBanner)
- StartSessionBanner에 크레딧 체크 로직(isCreditInsufficient) 추가
- UI 개선: 시작 버튼이 비활성화되었을 때 Tooltip을 통해 "크레딧이 부족하여 학습을 시작할 수 없어요" 메시지 제공
- 헤더 개선: LearningHeader에 현재 잔여 크레딧을 보여주는 배지 UI 추가 및 Tooltip을 통해 크레딧이 의미하는 바가 무엇인지 안내

### 2. Test: E2E 테스트 보완
- learning.spec.ts: 크레딧이 0일 때 버튼이 Disabled 상태인지, 툴팁이 뜨는지 확인하는 테스트 케이스 추가

<br/>

## 📷 스크린샷

<img width="3063" height="1764" alt="image" src="https://github.com/user-attachments/assets/b6cc7a86-d5a9-4563-910d-1609bc5e63aa" />
e2e 테스트 통과 확인

<br/>

## ✅ 체크리스트

- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `5분`
> 리뷰어에게 남기고 싶은 말) 

크레딧 수에 따라 세션 시작을 차단함에따라 남은 크레딧 갯수 파악이 필수적일것이라 생각하여 해당 UI 요소를 추가했습니다.

크레딧이라는 개념이 처음 이용하는 사용자 입장에서 특히 learning 페이지에서는 어떤 개념일지 더 와닿지 않을 것 같아

남은 크레딧 개수 부분에 마우스를 올리면 크레딧이 답변 제출 가능횟수라는 개념을 안내하도록 리팩토링했습니다.
<br/>

## 📄 추가 전달 사항
문제 해결과정은 wiki에 작성!! 토의를 하고 싶다면 discussion으로!

- 공유한 내용이나 반영된 내용은 wiki에 이어서 작성(사고나 작업의 변화를 보기 위해 기존의 내용 수정X)
