### PR TITLE
Feat/#189 진행중인 세션 이어하기 기능 구현

### DIFF
--- a/apps/be/src/learning/sessions/controllers/sessions.controller.ts
+++ b/apps/be/src/learning/sessions/controllers/sessions.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, ParseIntPipe, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -73,6 +73,74 @@ export class SessionsController {
   ) {
     const userId = user.id;
     return this.sessionsService.createSession(userId, dto);
+  }
+
+  /**
+   * 현재 진행중인 학습 세션이 있다면 해당 세션 정보를 반환한다.
+   */
+  @Get('active-session')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: '진행 중인 세션 조회',
+    description: '사용자의 현재 활성화된(종료되지 않은) 세션이 있는지 확인합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '조회 성공',
+    schema: {
+      example: {
+        hasSession: true,
+        sessionId: 15,
+        currentQuestionCount: 2,
+      },
+    },
+  })
+  async getInProgressSession(@ActiveUser() user: { id: number }) {
+    return this.sessionsService.getInProgressSession(user.id);
+  }
+
+  /**
+   * 진행 중인 세션의 현재 상태(문제, 진행도 등)를 반환한다.
+   * 크레딧을 차감하지 않고 현재 상태를 반환한다.
+   */
+  @Get(':sessionId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: '세션 이어하기 (상태 복구)',
+    description: '진행 중인 세션의 현재 상태(문제, 진행도 등)를 반환하여 학습을 재개합니다.',
+  })
+  @ApiParam({
+    name: 'sessionId',
+    description: '이어할 세션 ID',
+    type: Number,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '세션 정보 로드 성공',
+    schema: {
+      example: {
+        sessionId: 15,
+        currentQuestionCount: 2,
+        remainedCredit: 19,
+        question: {
+          questionId: 105,
+          content: 'TCP와 UDP의 차이는?',
+          guide: '연결 지향성 여부를 중심으로...',
+          category: 'NETWORK',
+          difficulty: 'MEDIUM',
+          timeLimit: 300,
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: '유효하지 않은 세션' })
+  async resumeSession(
+    @ActiveUser() user: { id: number },
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
+    return this.sessionsService.resumeSession(sessionId, user.id);
   }
 
   @Post(':sessionId/next-question')

--- a/apps/be/src/learning/sessions/services/sessions.service.ts
+++ b/apps/be/src/learning/sessions/services/sessions.service.ts
@@ -96,6 +96,86 @@ export class SessionsService {
   }
 
   /**
+   * 사용자의 진행 중인(Active) 세션이 있는지 확인한다.
+   */
+  async getInProgressSession(userId: number) {
+    const activeSession = await this.sessionsRepository.findActiveSessionByUserId(userId);
+
+    if (!activeSession) {
+      return {
+        hasSession: false,
+        sessionId: null,
+        currentQuestionCount: null,
+      };
+    }
+
+    return {
+      hasSession: true,
+      sessionId: activeSession.id,
+      currentQuestionCount: activeSession.currentQuestionCount,
+    };
+  }
+
+  /**
+   * 세션 이어하기: 현재 세션 상태를 복구한다.
+   * 주의: 크레딧을 차감하지 않으며, 현재 카운트에 맞는 질문을 제공한다.
+   */
+  async resumeSession(sessionId: number, userId: number) {
+    const session = await this.sessionsRepository.findById(sessionId);
+
+    if (!session) {
+      throw new NotFoundException({
+        code: 'SESSION_NOT_FOUND',
+        message: '세션을 찾을 수 없습니다.',
+      });
+    }
+
+    if (session.completedAt || session.status === 'COMPLETED') {
+      throw new ConflictException({
+        code: 'SESSION_COMPLETED',
+        message: '이미 종료된 세션입니다.',
+      });
+    }
+
+    if (session.userId !== userId) {
+      throw new BadRequestException({ code: 'FORBIDDEN', message: '세션 소유자가 아닙니다.' });
+    }
+
+    const remainedCredit = await this.userCreditsRepository.getTotalCredit(userId);
+
+    // Note: DB에 '현재 진행중인 questionId'를 저장하지 않는 구조이므로,
+    // 이어하기 시 '동일한 조건'의 질문을 다시 뽑아서 제공합니다.
+    const question = await this.questionService.pickOne(
+      session.category as Domain,
+      session.difficulty as Difficulty,
+    );
+
+    if (!question) {
+      // 극단적인 경우: 질문 데이터가 부족하여 못 가져올 때
+      throw new NotFoundException({
+        code: 'QUESTION_UNAVAILABLE',
+        message: '제공할 질문을 찾을 수 없습니다.',
+      });
+    }
+
+    const guide = this.guideBuilder.build(question.mustInclude);
+
+    return {
+      sessionId: session.id,
+      currentQuestionCount: session.currentQuestionCount,
+      remainedCredit: remainedCredit,
+      question: {
+        questionId: question.questionId,
+        content: question.content,
+        guide,
+        category: question.domain,
+        difficulty: question.difficulty,
+        timeLimit: question.timeLimitSec,
+      },
+    };
+  }
+
+  /**
    * 진행 중인 세션의 다음 질문을 조회하고 카운트/크레딧을 반영한다.
    * 질문이 없으면 세션을 종료 처리하고 종료 상태를 응답한다.
    */

--- a/apps/fe/__test__/e2e/auth.spec.ts
+++ b/apps/fe/__test__/e2e/auth.spec.ts
@@ -196,7 +196,7 @@ test.describe('1. 🔐 인증 및 유효성 검사 (Auth & Validation)', () => {
     // 1. 가짜 유저 데이터 정의
     const mockUserInfo = {
       profile: {
-        nickname: 'YeonShin',
+        nickname: 'test',
         profileImage: null,
         bio: '테스트 계정입니다.',
       },
@@ -244,6 +244,6 @@ test.describe('1. 🔐 인증 및 유효성 검사 (Auth & Validation)', () => {
     await expect(page).toHaveURL('/');
 
     // 상단 바 내 닉네임 확인
-    await expect(page.getByText('YeonShin')).toBeVisible();
+    await expect(page.getByText('test')).toBeVisible();
   });
 });

--- a/apps/fe/__test__/e2e/learning-setup.spec.ts
+++ b/apps/fe/__test__/e2e/learning-setup.spec.ts
@@ -2,7 +2,7 @@ import { type Page, type Route, expect, test } from '@playwright/test';
 
 // 공통 API Mocking 데이터
 const mockUserInfo = {
-  profile: { nickname: 'YeonShin', profileImage: null, bio: '테스트' },
+  profile: { nickname: 'test', profileImage: null, bio: '테스트' },
   progression: { level: 5, currentXp: 1200, requiredXpForNextLevel: 2000, lp: 450 },
   studyStats: { solvedProblemCount: 120, streak: 7, totalStudyTime: 36000 },
   remainingCredit: 20,
@@ -29,7 +29,7 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
     page,
   }) => {
     // 1. 닉네임 및 환영 문구 확인
-    await expect(page.getByText('안녕하세요, YeonShin님!')).toBeVisible();
+    await expect(page.getByText('안녕하세요, test님!')).toBeVisible();
 
     // 2. 스트릭 확인
     await expect(page.getByText('연속 7일 학습 중')).toBeVisible();
@@ -45,7 +45,7 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
     await expect(page.getByText('다음 레벨: 6 Lv')).toBeVisible();
 
     const sideBar = page.locator('aside');
-    await expect(sideBar.getByText('YeonShin')).toBeVisible();
+    await expect(sideBar.getByText('test')).toBeVisible();
     await expect(sideBar.getByText('Level 5 • 1200 XP')).toBeVisible();
   });
 
@@ -55,6 +55,13 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
   test('주제와 난이도를 선택하면 학습 시작 버튼이 활성화되고 페이지가 이동해야 한다', async ({
     page,
   }) => {
+    await page.route('**/learning/sessions/active-session', async (route) => {
+      await route.fulfill({
+        status: 200,
+        json: { hasSession: false, sessionId: null },
+      });
+    });
+
     // 1. 초기 상태: 난이도 설정 및 시작 버튼은 보이지 않아야 함 (opacity-0)
     const difficultySection = page.locator('section:has-text("난이도 설정")');
     const startSection = page.locator('section:has-text("오늘의 AI 튜터가 준비되었습니다.")');
@@ -101,28 +108,33 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
    */
   test.describe('진행 중인 세션 이어하기', () => {
     test.beforeEach(async ({ page }) => {
-      // 1. 유저 정보 Mocking
-      await page.route('**/api/users/me', async (route) => {
+      // 1. 진행 중인 세션 정보 Mocking
+      await page.route('**/api/learning/sessions/active-session', async (route) => {
         await route.fulfill({
           status: 200,
           json: {
-            profile: { nickname: 'YeonShin' },
-            progression: { level: 5, currentXp: 1200, requiredXpForNextLevel: 2000 },
-            studyStats: { solvedProblemCount: 120, streak: 7, totalStudyTime: 36000 },
-            remainingCredit: 20,
+            hasSession: true,
+            sessionId: 99,
+            currentQuestionCount: 2,
           },
         });
       });
 
-      // 2. 진행 중인 세션 정보 Mocking
-      await page.route('**/api/learning/active-session', async (route) => {
+      // 2. 세션 이어하기 데이터 Mocking
+      await page.route('**/api/learning/sessions/99', async (route) => {
         await route.fulfill({
           status: 200,
           json: {
             sessionId: 99,
+            currentQuestionCount: 2,
+            remainedCredit: 20,
             question: {
               questionId: 501,
               content: 'TCP와 UDP의 차이점에 대해 설명해주세요.',
+              guide: '연결 지향성',
+              category: 'NETWORK',
+              difficulty: 'MEDIUM',
+              timeLimit: 300,
             },
           },
         });
@@ -133,6 +145,15 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
       page,
     }) => {
       await page.goto('/learning');
+
+      await expect(page.getByRole('dialog')).toBeHidden();
+
+      await page.getByText('네트워크').click();
+      await expect(page.getByText('난이도 설정')).toBeVisible();
+
+      await page.getByText('중급').click();
+
+      await page.getByRole('button', { name: '학습 시작하기' }).click();
 
       // 3. Radix UI Dialog 노출 확인
       const dialog = page.getByRole('dialog');

--- a/apps/fe/__test__/e2e/learning-setup.spec.ts
+++ b/apps/fe/__test__/e2e/learning-setup.spec.ts
@@ -172,14 +172,13 @@ test.describe('2. 🏫 학습 대시보드 및 세션 설정 (Learning Setup)', 
     // 3. 시작 버튼 클릭 시도
     const startButton = page.getByRole('button', { name: '학습 시작하기' });
 
-    await page.route('**/api/learning/sessions', async (route) => {
-      await route.fulfill({
-        status: 409,
-        json: { message: '잔여 크레딧이 부족하여 세션을 진행할 수 없습니다.' },
-      });
-    });
+    // disabled 상태 확인
+    await expect(startButton).toBeDisabled();
 
-    await startButton.click();
-    await expect(page.getByText('잔여 크레딧이 부족하여 세션을 진행할 수 없습니다.')).toBeVisible();
+    // 툴팁 트리거 (강제 hover)
+    await startButton.hover({ force: true });
+
+    // 툴팁 텍스트 확인
+    await expect(page.getByText('크레딧이 부족하여 학습을 시작할 수 없어요')).toBeVisible();
   });
 });

--- a/apps/fe/src/apis/learning-api.ts
+++ b/apps/fe/src/apis/learning-api.ts
@@ -4,6 +4,7 @@ import type {
   AssessResponseDTO,
   CreateQuestionResponseDTO,
   FinishSessionResponseDTO,
+  GetActiveSessionResponseDTO,
   GetFeedbackResponseDTO,
   GetQuestionResponseDTO,
   SubmitRecordResponseDTO,
@@ -35,6 +36,26 @@ export const startSessionApi = async (
     category,
     difficulty,
   });
+  return data;
+};
+
+/**
+ * 진행 중인 세션 조회
+ */
+export const getInProgressSessionApi = async () => {
+  const { data } = await axiosInstance.get<GetActiveSessionResponseDTO>(
+    '/learning/sessions/active-session',
+  );
+  return data;
+};
+
+/**
+ * 세션 이어하기 (상태 복구)
+ */
+export const resumeSessionApi = async (sessionId: number) => {
+  const { data } = await axiosInstance.get<CreateQuestionResponseDTO>(
+    `/learning/sessions/${sessionId}`,
+  );
   return data;
 };
 

--- a/apps/fe/src/features/learning/components/learning/difficulty-selector.tsx
+++ b/apps/fe/src/features/learning/components/learning/difficulty-selector.tsx
@@ -1,0 +1,63 @@
+import type { QUESTION_DIFFICULTY_CONFIG } from '@/constants/question';
+import type { QuestionDifficulty } from '@repo/shared/constants/learning';
+
+type DifficultySelectorProps = {
+  isVisible: boolean;
+  options: (typeof QUESTION_DIFFICULTY_CONFIG)[keyof typeof QUESTION_DIFFICULTY_CONFIG][];
+  selectedDifficulty: QuestionDifficulty | null;
+  onSelect: (value: QuestionDifficulty) => void;
+};
+
+const DifficultySelector = ({
+  isVisible,
+  options,
+  selectedDifficulty,
+  onSelect,
+}: DifficultySelectorProps) => {
+  return (
+    <section
+      className={`rounded-2xl border border-gray bg-white p-5 shadow-sm transition-all duration-700 ease-in-out md:p-8 ${
+        isVisible
+          ? 'visible translate-y-0 opacity-100'
+          : 'pointer-events-none invisible translate-y-10 opacity-0'
+      }`}
+      aria-hidden={!isVisible}
+    >
+      <h2 className="mb-4 text-lg font-bold md:text-xl">난이도 설정</h2>
+      <ul className="flex w-full rounded-lg bg-gray p-1">
+        {options.map((diff) => {
+          const isSelected = selectedDifficulty === diff.value;
+          return (
+            <li key={diff.value} className="flex-1">
+              <label
+                className={`flex cursor-pointer items-center justify-center rounded-md py-3 text-sm transition-all outline-none focus-within:bg-white active:scale-95 md:py-2 md:active:scale-100 ${
+                  isSelected
+                    ? 'bg-white font-bold text-black shadow-sm'
+                    : 'font-medium text-dark-gray hover:text-black'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="difficulty-level"
+                  value={diff.value}
+                  checked={isSelected}
+                  onChange={() => onSelect(diff.value)}
+                  className="sr-only"
+                />
+                {diff.label}
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="mt-3 flex items-start gap-2 text-xs text-dark-gray md:items-center">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-primary text-[0.625rem] text-primary">
+          i
+        </span>
+        <span>전공자 수준의 심화 질문이 출제됩니다.</span>
+      </div>
+    </section>
+  );
+};
+
+export default DifficultySelector;

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -28,7 +28,7 @@ const LearningHeader = ({
           학습하기
         </Link>
       </div>
-      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-center">
         <div>
           <h1 className="mb-2 text-lg font-bold md:text-3xl">안녕하세요, {nickname}님! 👋</h1>
           <p className="text-sm text-dark-gray md:text-base">

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -37,17 +37,15 @@ const LearningHeader = ({
             남았어요.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-3 self-start md:self-auto">
+        <div className="flex flex-wrap gap-3">
           <Tooltip.Provider delayDuration={200}>
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
-                <div className="cursor-help rounded-full border border-primary/20 bg-primary/5 px-4 py-2 shadow-xs transition-colors hover:bg-primary/10">
-                  <div className="flex items-center gap-2">
-                    <Coins className="h-5 w-5 text-primary" />
-                    <span className="text-sm font-bold text-primary">
-                      {remainingCredit.toLocaleString()} 크레딧
-                    </span>
-                  </div>
+                <div className="flex cursor-help items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-2 shadow-xs transition-colors hover:bg-primary/10">
+                  <Coins className="h-5 w-5 text-primary" />
+                  <span className="text-sm font-bold text-primary">
+                    {remainingCredit.toLocaleString()} 크레딧
+                  </span>
                 </div>
               </Tooltip.Trigger>
               <Tooltip.Portal>
@@ -64,11 +62,9 @@ const LearningHeader = ({
             </Tooltip.Root>
           </Tooltip.Provider>
 
-          <div className="rounded-full border border-gray bg-white px-4 py-2 shadow-xs">
-            <div className="flex items-center gap-2">
-              <Flame className="h-5 w-5 text-orange" />
-              <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
-            </div>
+          <div className="flex items-center gap-2 rounded-full border border-gray bg-white px-4 py-2 shadow-xs">
+            <Flame className="h-5 w-5 text-orange" />
+            <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
           </div>
         </div>
       </div>

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -1,0 +1,66 @@
+import type { UserInfoResponseDto } from '@repo/shared/types/user';
+import { Link } from '@tanstack/react-router';
+
+import { Flame } from 'lucide-react';
+
+type LearningHeaderProps = {
+  nickname: string;
+  studyStats: UserInfoResponseDto['studyStats'];
+  progression: UserInfoResponseDto['progression'];
+  progress: number;
+  calculatedPercent: number;
+};
+
+const LearningHeader = ({
+  nickname,
+  studyStats,
+  progression,
+  progress,
+  calculatedPercent,
+}: LearningHeaderProps) => {
+  return (
+    <header className="space-y-2">
+      <div className="mb-4 text-sm font-bold">
+        <Link to="/learning" className="text-primary">
+          학습하기
+        </Link>
+      </div>
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+        <div>
+          <h1 className="mb-2 text-lg font-bold md:text-3xl">안녕하세요, {nickname}님! 👋</h1>
+          <p className="text-sm text-dark-gray md:text-base">
+            <span className="hidden md:inline">오늘도 CS 지식을 쌓아볼까요?</span> 목표 달성까지
+            <span className="mx-1 font-bold text-primary">{100 - calculatedPercent}%</span>
+            남았어요.
+          </p>
+        </div>
+        <div className="self-start rounded-full border border-gray bg-white px-4 py-2 shadow-sm md:self-auto">
+          <div className="flex items-center gap-2">
+            <Flame className="h-5 w-5 text-orange" />
+            <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
+          </div>
+        </div>
+      </div>
+
+      {/* [모바일 전용] 레벨 프로그레스 바 */}
+      <div className="mt-4 block rounded-xl md:hidden">
+        <div className="mb-2 flex justify-between text-xs font-bold text-dark-gray">
+          <span>
+            {progression?.level} Lv ({progression?.currentXp} XP)
+          </span>
+          <span className="text-gray-400">
+            {progression?.level + 1} Lv ({progression.requiredXpForNextLevel} XP)
+          </span>
+        </div>
+        <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default LearningHeader;

--- a/apps/fe/src/features/learning/components/learning/learning-header.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-header.tsx
@@ -1,12 +1,14 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
 import type { UserInfoResponseDto } from '@repo/shared/types/user';
 import { Link } from '@tanstack/react-router';
 
-import { Flame } from 'lucide-react';
+import { Coins, Flame } from 'lucide-react';
 
 type LearningHeaderProps = {
   nickname: string;
   studyStats: UserInfoResponseDto['studyStats'];
   progression: UserInfoResponseDto['progression'];
+  remainingCredit: number;
   progress: number;
   calculatedPercent: number;
 };
@@ -15,6 +17,7 @@ const LearningHeader = ({
   nickname,
   studyStats,
   progression,
+  remainingCredit,
   progress,
   calculatedPercent,
 }: LearningHeaderProps) => {
@@ -34,10 +37,38 @@ const LearningHeader = ({
             남았어요.
           </p>
         </div>
-        <div className="self-start rounded-full border border-gray bg-white px-4 py-2 shadow-sm md:self-auto">
-          <div className="flex items-center gap-2">
-            <Flame className="h-5 w-5 text-orange" />
-            <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
+        <div className="flex flex-wrap items-center gap-3 self-start md:self-auto">
+          <Tooltip.Provider delayDuration={200}>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <div className="cursor-help rounded-full border border-primary/20 bg-primary/5 px-4 py-2 shadow-xs transition-colors hover:bg-primary/10">
+                  <div className="flex items-center gap-2">
+                    <Coins className="h-5 w-5 text-primary" />
+                    <span className="text-sm font-bold text-primary">
+                      {remainingCredit.toLocaleString()} 크레딧
+                    </span>
+                  </div>
+                </div>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  side="bottom"
+                  sideOffset={5}
+                  className="animate-in fade-in-0 zoom-in-95 z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+                >
+                  답변을 제출할 수 있는 횟수가
+                  <span className="font-bold text-primary"> {remainingCredit}회</span> 남았습니다
+                  <Tooltip.Arrow className="fill-white" />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+
+          <div className="rounded-full border border-gray bg-white px-4 py-2 shadow-xs">
+            <div className="flex items-center gap-2">
+              <Flame className="h-5 w-5 text-orange" />
+              <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/fe/src/features/learning/components/learning/learning-stats-section.tsx
+++ b/apps/fe/src/features/learning/components/learning/learning-stats-section.tsx
@@ -1,0 +1,85 @@
+import type { UserInfoResponseDto } from '@repo/shared/types/user';
+
+import { TrendingUp } from 'lucide-react';
+
+type LearningStatsSectionProps = {
+  progression: UserInfoResponseDto['progression'];
+  studyStats: UserInfoResponseDto['studyStats'];
+  progress: number;
+  calculatedPercent: number;
+};
+
+const LearningStatsSection = ({
+  progression,
+  studyStats,
+  progress,
+  calculatedPercent,
+}: LearningStatsSectionProps) => {
+  return (
+    <>
+      <section className="hidden grid-cols-1 gap-4 md:grid md:gap-6 lg:grid-cols-3">
+        {/* 경험치 바 카드 */}
+        <div className="rounded-2xl border border-gray bg-white p-5 shadow-sm md:col-span-2 md:p-6">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <div className="rounded-md bg-primary/10 p-1.5">
+                <TrendingUp className="h-5 w-5 text-primary" />
+              </div>
+              <h2 className="text-lg font-bold">현재 레벨 경험치</h2>
+            </div>
+            <span className="text-sm text-dark-gray">
+              다음 레벨: {(progression?.level ?? 0) + 1} Lv
+            </span>
+          </div>
+          <div className="mb-2 flex items-end gap-2">
+            <span className="text-3xl font-extrabold text-black md:text-4xl">
+              {calculatedPercent}%
+            </span>
+            <span className="mb-1 ml-auto text-xs text-dark-gray md:text-sm">
+              {progression?.currentXp} / {progression?.requiredXpForNextLevel} XP
+            </span>
+          </div>
+          <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        {/* 요약 통계 카드 */}
+        <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm md:p-6">
+          <h2 className="mb-4 text-lg font-bold">학습 요약</h2>
+          <div className="flex justify-between px-2 sm:justify-start sm:gap-20 sm:px-0">
+            <div>
+              <p className="mb-1 text-sm text-dark-gray">누적 답변</p>
+              <p className="text-2xl font-bold text-black">{studyStats?.solvedProblemCount}개</p>
+            </div>
+            <div>
+              <p className="mb-1 text-sm text-dark-gray">총 학습 시간</p>
+              <p className="text-2xl font-bold text-primary">
+                {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 모바일 전용 통계 카드 */}
+      <section className="grid grid-cols-2 gap-3 md:hidden">
+        <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
+          <p className="mb-2 text-sm text-dark-gray">누적 답변</p>
+          <p className="text-lg font-bold text-black">{studyStats?.solvedProblemCount}개</p>
+        </div>
+        <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
+          <p className="mb-2 text-sm text-dark-gray">총 학습 시간</p>
+          <p className="text-lg font-bold text-primary">
+            {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
+          </p>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default LearningStatsSection;

--- a/apps/fe/src/features/learning/components/learning/resume-session-modal.tsx
+++ b/apps/fe/src/features/learning/components/learning/resume-session-modal.tsx
@@ -1,0 +1,65 @@
+import * as Dialog from '@radix-ui/react-dialog';
+
+import { History, XCircle } from 'lucide-react';
+
+type ResumeSessionModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onResume: () => void;
+  onAbort: () => void;
+  isLoading: boolean;
+};
+
+const ResumeSessionModal = ({
+  isOpen,
+  onOpenChange,
+  onResume,
+  onAbort,
+  isLoading,
+}: ResumeSessionModalProps) => {
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="animate-in fade-in-0 fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
+
+        <Dialog.Content className="animate-in fade-in-0 zoom-in-95 fixed top-[50%] left-[50%] z-50 w-full max-w-md translate-x-[-50%] translate-y-[-50%] rounded-2xl bg-white p-6 shadow-lg duration-200">
+          <div className="mb-4 flex flex-col items-center gap-3 text-center">
+            <div className="rounded-full bg-primary/10 p-3">
+              <History className="h-8 w-8 text-primary" />
+            </div>
+
+            <Dialog.Title className="text-xl font-bold text-slate-900">
+              진행 중인 학습이 있습니다
+            </Dialog.Title>
+
+            <Dialog.Description className="text-sm text-slate-500">
+              이전에 완료하지 못한 학습 세션이 남아있습니다.
+              <br />
+              이어서 진행하시겠습니까?
+            </Dialog.Description>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row-reverse">
+            <button
+              onClick={onResume}
+              disabled={isLoading}
+              className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-primary px-4 font-bold text-white transition-colors hover:bg-primary/90 disabled:opacity-50 sm:flex-1"
+            >
+              {isLoading ? '불러오는 중...' : '이어하기'}
+            </button>
+            <button
+              onClick={onAbort}
+              disabled={isLoading}
+              className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 font-medium text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50 sm:flex-1"
+            >
+              <XCircle className="h-4 w-4" />
+              종료하기
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default ResumeSessionModal;

--- a/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
+++ b/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
@@ -1,0 +1,88 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+
+import { Mic } from 'lucide-react';
+
+type StartSessionBannerProps = {
+  isVisible: boolean;
+  selectedTopicLabel?: string;
+  selectedDifficultyLabel?: string;
+  isLoading: boolean;
+  isStartDisabled: boolean;
+  isCreditInsufficient: boolean;
+  onStart: () => void;
+};
+
+const StartSessionBanner = ({
+  isVisible,
+  selectedTopicLabel,
+  selectedDifficultyLabel,
+  isLoading,
+  isStartDisabled,
+  isCreditInsufficient,
+  onStart,
+}: StartSessionBannerProps) => {
+  return (
+    <section
+      className={`relative flex transform flex-col items-center justify-between overflow-hidden rounded-2xl bg-black p-6 text-white transition-all duration-700 ease-in-out md:flex-row md:p-8 ${
+        isVisible
+          ? 'visible translate-y-0 opacity-100'
+          : 'pointer-events-none invisible translate-y-10 opacity-0'
+      }`}
+      aria-hidden={!isVisible}
+    >
+      <div className="pointer-events-none absolute top-0 left-0 h-full w-full bg-linear-to-r from-primary/20 to-transparent"></div>
+
+      <div className="z-10 mb-6 w-full md:mb-0 md:w-auto">
+        <span className="mb-2 inline-block rounded-3xl border border-primary/30 bg-primary/30 px-2 py-1 text-xs text-primary">
+          AI Learning
+        </span>
+        <p className="mb-1 text-lg font-bold md:text-xl">오늘의 AI 튜터가 준비되었습니다.</p>
+        <p className="text-sm text-gray">
+          선택하신 <span className="mx-1 font-bold text-primary">{selectedTopicLabel}</span> 주제 /
+          <span className="mx-1 font-bold text-primary">{selectedDifficultyLabel}</span> 난이도
+        </p>
+      </div>
+
+      <Tooltip.Provider delayDuration={200}>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
+              <button
+                onClick={onStart}
+                disabled={isStartDisabled}
+                className={`flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${
+                  isStartDisabled
+                    ? 'cursor-not-allowed bg-dark-gray'
+                    : 'bg-primary hover:bg-primary/80'
+                }`}
+              >
+                {isLoading ? (
+                  <span>질문 생성 중...</span>
+                ) : (
+                  <>
+                    <Mic className="h-5 w-5" />
+                    <span className="text-lg md:text-base">학습 시작하기</span>
+                  </>
+                )}
+              </button>
+            </span>
+          </Tooltip.Trigger>
+          {isCreditInsufficient && (
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="top"
+                sideOffset={8}
+                className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+              >
+                크레딧이 부족하여 학습을 시작할 수 없어요
+                <Tooltip.Arrow className="fill-white" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          )}
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </section>
+  );
+};
+
+export default StartSessionBanner;

--- a/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
+++ b/apps/fe/src/features/learning/components/learning/start-sesssion-banner.tsx
@@ -44,7 +44,7 @@ const StartSessionBanner = ({
       </div>
 
       <Tooltip.Provider delayDuration={200}>
-        <Tooltip.Root>
+        <Tooltip.Root open={isCreditInsufficient ? undefined : false}>
           <Tooltip.Trigger asChild>
             <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
               <button
@@ -67,18 +67,16 @@ const StartSessionBanner = ({
               </button>
             </span>
           </Tooltip.Trigger>
-          {isCreditInsufficient && (
-            <Tooltip.Portal>
-              <Tooltip.Content
-                side="top"
-                sideOffset={8}
-                className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
-              >
-                크레딧이 부족하여 학습을 시작할 수 없어요
-                <Tooltip.Arrow className="fill-white" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          )}
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="top"
+              sideOffset={8}
+              className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+            >
+              크레딧이 부족하여 학습을 시작할 수 없어요
+              <Tooltip.Arrow className="fill-white" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </Tooltip.Provider>
     </section>

--- a/apps/fe/src/features/learning/components/learning/topic-selector.tsx
+++ b/apps/fe/src/features/learning/components/learning/topic-selector.tsx
@@ -1,0 +1,56 @@
+import type { QUESTION_CATEGORY_CONFIG } from '@/constants/question';
+import type { QuestionCategory } from '@repo/shared/constants/learning';
+
+import { ListFilter } from 'lucide-react';
+
+type TopicSelectorProps = {
+  options: (typeof QUESTION_CATEGORY_CONFIG)[keyof typeof QUESTION_CATEGORY_CONFIG][];
+  selectedTopic: QuestionCategory | null;
+  onSelect: (id: QuestionCategory) => void;
+};
+
+const TopicSelector = ({ options, selectedTopic, onSelect }: TopicSelectorProps) => {
+  return (
+    <section>
+      <div className="mb-4 flex items-center gap-2 md:mb-6">
+        <ListFilter className="h-5 w-5 text-primary" aria-hidden="true" />
+        <h2 className="text-lg font-bold md:text-xl">학습 주제 선택 (Learning Path)</h2>
+      </div>
+
+      <ul className="scrollbar-hide flex gap-4 overflow-x-auto pb-4 md:grid md:grid-cols-2 md:gap-3 md:overflow-visible lg:grid-cols-4">
+        {options.map((topic) => {
+          const isSelected = selectedTopic === topic.id;
+          return (
+            <li key={topic.id} className="min-w-55 md:min-w-0">
+              <label
+                className={`group block h-full cursor-pointer rounded-xl border-2 p-4 transition-all outline-none focus-within:bg-white active:scale-95 md:active:scale-100 ${
+                  isSelected
+                    ? 'border-primary bg-white shadow-md'
+                    : 'border-transparent bg-transparent hover:border-gray hover:bg-white'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="learning-topic"
+                  value={topic.id}
+                  checked={isSelected}
+                  onChange={() => onSelect(topic.id)}
+                  className="sr-only"
+                />
+                <div
+                  className={`mb-3 transition-colors group-hover:text-primary ${isSelected ? 'text-primary' : 'text-black'}`}
+                >
+                  <topic.Icon className="h-6 w-6" />
+                </div>
+                <p className="mb-1 text-lg font-bold">{topic.label}</p>
+                <p className="text-xs text-dark-gray">{topic.description}</p>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default TopicSelector;

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -59,6 +59,7 @@ const LearningPage = () => {
           nickname={profile.nickname}
           studyStats={studyStats}
           progression={progression}
+          remainingCredit={remainingCredit}
           progress={progress}
           calculatedPercent={calculatedPercent}
         />

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -5,6 +5,7 @@ import { QUESTION_CATEGORY_CONFIG, QUESTION_DIFFICULTY_CONFIG } from '@/constant
 import { useProgressAnimation } from '@/features/learning/lib/hooks/use-progress-animation';
 import useLearningSession from '@/lib/stores/learning-session';
 import { useUserStore } from '@/lib/stores/user-store';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { type QuestionCategory, type QuestionDifficulty } from '@repo/shared/constants/learning';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
@@ -17,7 +18,7 @@ const LearningPage = () => {
 
   const setQuestion = useLearningSession((state) => state.setQuestion);
 
-  const { profile, progression, studyStats } = userInfo;
+  const { profile, progression, studyStats, remainingCredit } = userInfo;
 
   const { progress, calculatedPercent } = useProgressAnimation(
     progression?.currentXp ?? 0,
@@ -31,8 +32,13 @@ const LearningPage = () => {
   const topicOptions = Object.values(QUESTION_CATEGORY_CONFIG);
   const difficultyOptions = Object.values(QUESTION_DIFFICULTY_CONFIG);
 
+  const isCreditInsufficient = remainingCredit <= 0;
+  const isStartDisabled = isLoading || isCreditInsufficient;
+
   const handleStartClick = async () => {
-    if (!selectedTopic || !selectedDifficulty) return;
+    if (!selectedTopic || !selectedDifficulty || isCreditInsufficient) return;
+
+    setIsLoading(true);
     try {
       const data = await startSessionApi(selectedTopic, selectedDifficulty);
       setQuestion(data);
@@ -268,20 +274,44 @@ const LearningPage = () => {
             </p>
           </div>
 
-          <button
-            onClick={handleStartClick}
-            disabled={isLoading}
-            className={`z-10 flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${isLoading ? `cursor-not-allowed bg-gray-600` : `bg-primary hover:bg-primary/80`} `}
-          >
-            {isLoading ? (
-              <span>질문 생성 중...</span>
-            ) : (
-              <>
-                <Mic className="h-5 w-5" />
-                <span className="text-lg md:text-base">학습 시작하기</span>
-              </>
-            )}
-          </button>
+          <Tooltip.Provider delayDuration={200}>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
+                  <button
+                    onClick={handleStartClick}
+                    disabled={isStartDisabled}
+                    className={`flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${
+                      isStartDisabled
+                        ? `cursor-not-allowed bg-dark-gray`
+                        : `bg-primary hover:bg-primary/80`
+                    } `}
+                  >
+                    {isLoading ? (
+                      <span>질문 생성 중...</span>
+                    ) : (
+                      <>
+                        <Mic className="h-5 w-5" />
+                        <span className="text-lg md:text-base">학습 시작하기</span>
+                      </>
+                    )}
+                  </button>
+                </span>
+              </Tooltip.Trigger>
+              {isCreditInsufficient && (
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    side="top"
+                    sideOffset={8}
+                    className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
+                  >
+                    크레딧이 부족하여 학습을 시작할 수 없어요
+                    <Tooltip.Arrow className="fill-white" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              )}
+            </Tooltip.Root>
+          </Tooltip.Provider>
         </section>
       </div>
     </div>

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -2,32 +2,32 @@ import { useState } from 'react';
 
 import { startSessionApi } from '@/apis/learning-api';
 import { QUESTION_CATEGORY_CONFIG, QUESTION_DIFFICULTY_CONFIG } from '@/constants/question';
+import DifficultySelector from '@/features/learning/components/learning/difficulty-selector';
+import LearningHeader from '@/features/learning/components/learning/learning-header';
+import LearningStatsSection from '@/features/learning/components/learning/learning-stats-section';
+import StartSessionBanner from '@/features/learning/components/learning/start-sesssion-banner';
+import TopicSelector from '@/features/learning/components/learning/topic-selector';
 import { useProgressAnimation } from '@/features/learning/lib/hooks/use-progress-animation';
 import useLearningSession from '@/lib/stores/learning-session';
 import { useUserStore } from '@/lib/stores/user-store';
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { type QuestionCategory, type QuestionDifficulty } from '@repo/shared/constants/learning';
-import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
-
-import { Flame, ListFilter, Mic, TrendingUp } from 'lucide-react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
 const LearningPage = () => {
   const userInfo = useUserStore((state) => state.userInfo)!;
-  const [isLoading, setIsLoading] = useState(false);
+  const setQuestion = useLearningSession((state) => state.setQuestion);
   const navigate = useNavigate();
 
-  const setQuestion = useLearningSession((state) => state.setQuestion);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedTopic, setSelectedTopic] = useState<QuestionCategory | null>(null);
+  const [selectedDifficulty, setSelectedDifficulty] = useState<QuestionDifficulty | null>(null);
 
   const { profile, progression, studyStats, remainingCredit } = userInfo;
-
   const { progress, calculatedPercent } = useProgressAnimation(
     progression?.currentXp ?? 0,
     progression?.requiredXpForNextLevel ?? 100,
     100,
   );
-
-  const [selectedTopic, setSelectedTopic] = useState<QuestionCategory | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<QuestionDifficulty | null>(null);
 
   const topicOptions = Object.values(QUESTION_CATEGORY_CONFIG);
   const difficultyOptions = Object.values(QUESTION_DIFFICULTY_CONFIG);
@@ -55,264 +55,49 @@ const LearningPage = () => {
     <div className="flex min-h-screen justify-center bg-pale-blue p-8">
       <div className="w-full max-w-5xl space-y-6 md:space-y-8">
         {/* 상단 헤더 */}
-        <header className="space-y-2">
-          <div className="mb-4 text-sm font-bold">
-            <Link to="/learning" className="text-primary">
-              학습하기
-            </Link>
-          </div>
-          <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
-            <div>
-              <h1 className="mb-2 text-lg font-bold md:text-3xl">
-                안녕하세요, {profile.nickname}
-                님! 👋
-              </h1>
-              <p className="text-sm text-dark-gray md:text-base">
-                <span className="hidden md:inline">오늘도 CS 지식을 쌓아볼까요?</span> 목표 달성까지
-                <span className="mx-1 font-bold text-primary">{100 - calculatedPercent}%</span>
-                남았어요.
-              </p>
-            </div>
-            <div className="self-start rounded-full border border-gray bg-white px-4 py-2 shadow-sm md:self-auto">
-              <div className="flex items-center gap-2">
-                <Flame className="h-5 w-5 text-orange" />
-                <span className="text-sm font-semibold">연속 {studyStats.streak}일 학습 중</span>
-              </div>
-            </div>
-          </div>
-          {/* [모바일 전용] 레벨 프로그레스 바 */}
-          <div className="mt-4 block rounded-xl md:hidden">
-            <div className="mb-2 flex justify-between text-xs font-bold text-dark-gray">
-              <span>
-                {progression?.level} Lv ({progression?.currentXp} XP)
-              </span>
-              <span className="text-gray-400">
-                {progression?.level + 1} Lv ({progression.requiredXpForNextLevel} XP)
-              </span>
-            </div>
-            <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-          </div>
-        </header>
+        <LearningHeader
+          nickname={profile.nickname}
+          studyStats={studyStats}
+          progression={progression}
+          progress={progress}
+          calculatedPercent={calculatedPercent}
+        />
 
         {/* 사용자 스탯 */}
-        <section className="hidden grid-cols-1 gap-4 md:grid md:gap-6 lg:grid-cols-3">
-          {/* 경험치 바 카드 */}
-          <div className="rounded-2xl border border-gray bg-white p-5 shadow-sm md:col-span-2 md:p-6">
-            <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <div className="rounded-md bg-primary/10 p-1.5">
-                  <TrendingUp className="h-5 w-5 text-primary" />
-                </div>
-                <h2 className="text-lg font-bold">현재 레벨 경험치</h2>
-              </div>
-              <span className="text-sm text-dark-gray">
-                다음 레벨: {(progression?.level ?? 0) + 1} Lv
-              </span>
-            </div>
-
-            <div className="mb-2 flex items-end gap-2">
-              <span className="text-3xl font-extrabold text-black md:text-4xl">
-                {calculatedPercent}%
-              </span>
-              <span className="mb-1 ml-auto text-xs text-dark-gray md:text-sm">
-                {progression?.currentXp} / {progression?.requiredXpForNextLevel} XP
-              </span>
-            </div>
-            <div className="h-3 w-full overflow-hidden rounded-full bg-gray">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-1000 ease-out"
-                style={{
-                  width: `${progress}%`,
-                }}
-              ></div>
-            </div>
-          </div>
-
-          {/* 요약 통계 카드 */}
-          <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm md:p-6">
-            <h2 className="mb-4 text-lg font-bold">학습 요약</h2>
-            <div className="flex justify-between px-2 sm:justify-start sm:gap-20 sm:px-0">
-              <div>
-                <p className="mb-1 text-sm text-dark-gray">누적 답변</p>
-                <p className="text-2xl font-bold text-black">{studyStats?.solvedProblemCount}개</p>
-              </div>
-              <div>
-                <p className="mb-1 text-sm text-dark-gray">총 학습 시간</p>
-                <p className="text-2xl font-bold text-primary">
-                  {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* 모바일 전용 통계 카드 */}
-        <section className="grid grid-cols-2 gap-3 md:hidden">
-          <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
-            <p className="mb-2 text-sm text-dark-gray">누적 답변</p>
-            <p className="text-lg font-bold text-black">{studyStats?.solvedProblemCount}개</p>
-          </div>
-          <div className="flex flex-col justify-center rounded-2xl border border-gray bg-white p-5 shadow-sm">
-            <p className="mb-2 text-sm text-dark-gray">총 학습 시간</p>
-            <p className="text-lg font-bold text-primary">
-              {Math.round((studyStats?.totalStudyTime ?? 0) / 60)}분
-            </p>
-          </div>
-        </section>
+        <LearningStatsSection
+          progression={progression}
+          studyStats={studyStats}
+          progress={progress}
+          calculatedPercent={calculatedPercent}
+        />
 
         {/* 주제 선택 */}
-        <section>
-          <div className="mb-4 flex items-center gap-2 md:mb-6">
-            <ListFilter className="h-5 w-5 text-primary" aria-hidden="true" />
-            <h2 className="text-lg font-bold md:text-xl">학습 주제 선택 (Learning Path)</h2>
-          </div>
-
-          <ul className="scrollbar-hide flex gap-4 overflow-x-auto pb-4 md:grid md:grid-cols-2 md:gap-3 md:overflow-visible lg:grid-cols-4">
-            {topicOptions.map((topic) => {
-              const isSelected = selectedTopic === topic.id;
-              return (
-                <li key={topic.id} className="min-w-55 md:min-w-0">
-                  <label
-                    className={`group block h-full cursor-pointer rounded-xl border-2 p-4 transition-all outline-none focus-within:bg-white active:scale-95 md:active:scale-100 ${
-                      isSelected
-                        ? 'border-primary bg-white shadow-md'
-                        : 'border-transparent bg-transparent hover:border-gray hover:bg-white'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="learning-topic"
-                      value={topic.id}
-                      checked={isSelected}
-                      onChange={() => setSelectedTopic(topic.id)}
-                      className="sr-only"
-                    />
-
-                    <div
-                      className={`mb-3 transition-colors group-hover:text-primary ${isSelected ? `text-primary` : `text-black`}`}
-                    >
-                      <topic.Icon className="h-6 w-6" />
-                    </div>
-                    <p className="mb-1 text-lg font-bold">{topic.label}</p>
-                    <p className="text-xs text-dark-gray">{topic.description}</p>
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
+        <TopicSelector
+          options={topicOptions}
+          selectedTopic={selectedTopic}
+          onSelect={setSelectedTopic}
+        />
 
         {/* 난이도 설정 */}
-        <section
-          className={`rounded-2xl border border-gray bg-white p-5 shadow-sm transition-all duration-700 ease-in-out md:p-8 ${selectedTopic !== null ? `visible translate-y-0 opacity-100` : `pointer-events-none invisible translate-y-10 opacity-0`}`}
-          aria-hidden={selectedTopic === null}
-        >
-          <h2 className="mb-4 text-lg font-bold md:text-xl">난이도 설정</h2>
-
-          <ul className="flex w-full rounded-lg bg-gray p-1">
-            {difficultyOptions.map((diff) => {
-              const isSelected = selectedDifficulty === diff.value;
-              return (
-                <li key={diff.value} className="flex-1">
-                  <label
-                    className={`flex cursor-pointer items-center justify-center rounded-md py-3 text-sm transition-all outline-none focus-within:bg-white active:scale-95 md:py-2 md:active:scale-100 ${
-                      isSelected
-                        ? 'bg-white font-bold text-black shadow-sm'
-                        : 'font-medium text-dark-gray hover:text-black'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="difficulty-level"
-                      value={diff.value}
-                      checked={isSelected}
-                      onChange={() => setSelectedDifficulty(diff.value)}
-                      className="sr-only"
-                    />
-                    {diff.label}
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
-
-          <div className="mt-3 flex items-start gap-2 text-xs text-dark-gray md:items-center">
-            <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-primary text-[0.625rem] text-primary">
-              i
-            </span>
-            <span>전공자 수준의 심화 질문이 출제됩니다.</span>
-          </div>
-        </section>
+        <DifficultySelector
+          isVisible={selectedTopic !== null}
+          options={difficultyOptions}
+          selectedDifficulty={selectedDifficulty}
+          onSelect={setSelectedDifficulty}
+        />
 
         {/* 학습 시작 버튼 섹션 */}
-        <section
-          className={`relative flex transform flex-col items-center justify-between overflow-hidden rounded-2xl bg-black p-6 text-white transition-all duration-700 ease-in-out md:flex-row md:p-8 ${selectedTopic !== null && selectedDifficulty !== null ? `visible translate-y-0 opacity-100` : `pointer-events-none invisible translate-y-10 opacity-0`}`}
-          aria-hidden={!selectedTopic || !selectedDifficulty}
-        >
-          <div className="pointer-events-none absolute top-0 left-0 h-full w-full bg-linear-to-r from-primary/20 to-transparent"></div>
-
-          <div className="z-10 mb-6 w-full md:mb-0 md:w-auto">
-            <span className="mb-2 inline-block rounded-3xl border border-primary/30 bg-primary/30 px-2 py-1 text-xs text-primary">
-              AI Learning
-            </span>
-            <p className="mb-1 text-lg font-bold md:text-xl">오늘의 AI 튜터가 준비되었습니다.</p>
-            <p className="text-sm text-gray">
-              선택하신
-              <span className="mx-1 font-bold text-primary">
-                {topicOptions.find((t) => t.id === selectedTopic)?.label}
-              </span>
-              주제 /
-              <span className="mx-1 font-bold text-primary">
-                {difficultyOptions.find((d) => d.value === selectedDifficulty)?.label}
-              </span>
-              난이도
-            </p>
-          </div>
-
-          <Tooltip.Provider delayDuration={200}>
-            <Tooltip.Root>
-              <Tooltip.Trigger asChild>
-                <span className="z-10 w-full md:w-auto" tabIndex={isStartDisabled ? 0 : undefined}>
-                  <button
-                    onClick={handleStartClick}
-                    disabled={isStartDisabled}
-                    className={`flex w-full items-center justify-center gap-2 rounded-lg px-6 py-4 font-medium text-white transition-colors md:w-auto md:py-3 ${
-                      isStartDisabled
-                        ? `cursor-not-allowed bg-dark-gray`
-                        : `bg-primary hover:bg-primary/80`
-                    } `}
-                  >
-                    {isLoading ? (
-                      <span>질문 생성 중...</span>
-                    ) : (
-                      <>
-                        <Mic className="h-5 w-5" />
-                        <span className="text-lg md:text-base">학습 시작하기</span>
-                      </>
-                    )}
-                  </button>
-                </span>
-              </Tooltip.Trigger>
-              {isCreditInsufficient && (
-                <Tooltip.Portal>
-                  <Tooltip.Content
-                    side="top"
-                    sideOffset={8}
-                    className="z-50 rounded-lg bg-white px-3 py-2 text-xs text-black shadow-lg"
-                  >
-                    크레딧이 부족하여 학습을 시작할 수 없어요
-                    <Tooltip.Arrow className="fill-white" />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              )}
-            </Tooltip.Root>
-          </Tooltip.Provider>
-        </section>
+        <StartSessionBanner
+          isVisible={selectedTopic !== null && selectedDifficulty !== null}
+          selectedTopicLabel={topicOptions.find((t) => t.id === selectedTopic)?.label}
+          selectedDifficultyLabel={
+            difficultyOptions.find((d) => d.value === selectedDifficulty)?.label
+          }
+          isLoading={isLoading}
+          isStartDisabled={isStartDisabled}
+          isCreditInsufficient={isCreditInsufficient}
+          onStart={handleStartClick}
+        />
       </div>
     </div>
   );

--- a/apps/fe/src/routes/_main/learning/index.tsx
+++ b/apps/fe/src/routes/_main/learning/index.tsx
@@ -1,10 +1,17 @@
 import { useState } from 'react';
 
-import { startSessionApi } from '@/apis/learning-api';
+import {
+  finishSessionApi,
+  getInProgressSessionApi,
+  resumeSessionApi,
+  startSessionApi,
+} from '@/apis/learning-api';
+import { getUserInfoApi } from '@/apis/user-api';
 import { QUESTION_CATEGORY_CONFIG, QUESTION_DIFFICULTY_CONFIG } from '@/constants/question';
 import DifficultySelector from '@/features/learning/components/learning/difficulty-selector';
 import LearningHeader from '@/features/learning/components/learning/learning-header';
 import LearningStatsSection from '@/features/learning/components/learning/learning-stats-section';
+import ResumeSessionModal from '@/features/learning/components/learning/resume-session-modal';
 import StartSessionBanner from '@/features/learning/components/learning/start-sesssion-banner';
 import TopicSelector from '@/features/learning/components/learning/topic-selector';
 import { useProgressAnimation } from '@/features/learning/lib/hooks/use-progress-animation';
@@ -14,13 +21,19 @@ import { type QuestionCategory, type QuestionDifficulty } from '@repo/shared/con
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
 const LearningPage = () => {
-  const userInfo = useUserStore((state) => state.userInfo)!;
-  const setQuestion = useLearningSession((state) => state.setQuestion);
   const navigate = useNavigate();
+
+  const userInfo = useUserStore((state) => state.userInfo)!;
+  const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const setQuestion = useLearningSession((state) => state.setQuestion);
+  const resetAnswerFlow = useLearningSession((state) => state.resetAnswerFlow);
 
   const [isLoading, setIsLoading] = useState(false);
   const [selectedTopic, setSelectedTopic] = useState<QuestionCategory | null>(null);
   const [selectedDifficulty, setSelectedDifficulty] = useState<QuestionDifficulty | null>(null);
+
+  const [resumeModalOpen, setResumeModalOpen] = useState(false);
+  const [detectedSessionId, setDetectedSessionId] = useState<number | null>(null);
 
   const { profile, progression, studyStats, remainingCredit } = userInfo;
   const { progress, calculatedPercent } = useProgressAnimation(
@@ -35,7 +48,8 @@ const LearningPage = () => {
   const isCreditInsufficient = remainingCredit <= 0;
   const isStartDisabled = isLoading || isCreditInsufficient;
 
-  const handleStartClick = async () => {
+  // 새로운 세션 생성 요청
+  const createNewSession = async () => {
     if (!selectedTopic || !selectedDifficulty || isCreditInsufficient) return;
 
     setIsLoading(true);
@@ -46,6 +60,77 @@ const LearningPage = () => {
       await navigate({ to: '/learning/question' });
     } catch (error) {
       console.error('Error starting session:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 학습 시작하기 버튼 클릭 시 진행중인 세션이 있는지 확인
+  const handleStartCheck = async () => {
+    if (!selectedTopic || !selectedDifficulty || isCreditInsufficient) return;
+
+    setIsLoading(true);
+
+    resetAnswerFlow();
+
+    try {
+      const data = await getInProgressSessionApi();
+
+      if (data.hasSession && data.sessionId) {
+        // 진행 중인 세션 있음
+        setDetectedSessionId(data.sessionId);
+        setResumeModalOpen(true);
+
+        setIsLoading(false);
+      } else {
+        // 진행 중인 세션 없음
+        await createNewSession();
+      }
+    } catch (error) {
+      console.error('Failed to check active session:', error);
+      setIsLoading(false);
+    }
+  };
+
+  // 세션 이어하기
+  const handleResumeSession = async () => {
+    if (!detectedSessionId) return;
+
+    setIsLoading(true);
+    try {
+      const sessionData = await resumeSessionApi(detectedSessionId);
+
+      setQuestion(sessionData);
+
+      setResumeModalOpen(false);
+      await navigate({ to: '/learning/question' });
+    } catch (error) {
+      // todo: 추후에 alert, console.error 코드 제거 후 리팩토링
+      console.error('Failed to resume session:', error);
+      alert('세션을 불러올 수 없습니다. 다시 시도해주세요.');
+      setResumeModalOpen(false);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 이어하지 않고 종료하기
+  const handleAbortSession = async () => {
+    if (!detectedSessionId) return;
+
+    setIsLoading(true);
+    try {
+      await finishSessionApi({ sessionId: detectedSessionId });
+
+      const updatedUserInfo = await getUserInfoApi();
+      setUserInfo(updatedUserInfo);
+
+      setResumeModalOpen(false);
+      setDetectedSessionId(null);
+    } catch (error) {
+      // todo: 추후에 alert, console.error 코드 제거 후 리팩토링
+      console.error('Failed to abort session:', error);
+      alert('세션 종료 처리에 실패했습니다.');
     } finally {
       setIsLoading(false);
     }
@@ -97,7 +182,17 @@ const LearningPage = () => {
           isLoading={isLoading}
           isStartDisabled={isStartDisabled}
           isCreditInsufficient={isCreditInsufficient}
-          onStart={handleStartClick}
+          onStart={handleStartCheck}
+        />
+
+        <ResumeSessionModal
+          isOpen={resumeModalOpen}
+          onOpenChange={(open) => {
+            if (!isLoading) setResumeModalOpen(open);
+          }}
+          onResume={handleResumeSession}
+          onAbort={handleAbortSession}
+          isLoading={isLoading}
         />
       </div>
     </div>

--- a/packages/shared/types/learning.ts
+++ b/packages/shared/types/learning.ts
@@ -22,6 +22,12 @@ export type CreateQuestionResponseDTO = {
   question: Question;
 };
 
+export type GetActiveSessionResponseDTO = {
+  hasSession: boolean;
+  sessionId: number | null;
+  currentQuestionCount: number | null;
+};
+
 // 다음 질문 조회 DTO
 export type GetQuestionResponseDTO = Pick<
   CreateQuestionResponseDTO,


### PR DESCRIPTION
## 🔗 관련 이슈

- close #189 

<br/>

## 🔍 작업 내용

### 0. 진행 중인 세션 조회 & 세션 이어하기 컨트롤러, 서비스 로직 구현

### 1. 진행 중인 세션 감지 로직 추가

- LearningPage에서 '학습 시작하기' 버튼 클릭 시 `getInProgressSessionApi`를 호출하여 Active Session 존재 여부를 확인합니다.
- 진행 중인 세션이 있을 경우, 새 세션을 생성하는 대신 이어하기 모달을 띄웁니다.

### 2. 이어하기 모달(ResumeSessionModal) 구현

- 이어하기: `resumeSessionApi`를 호출하여 서버로부터 세션 정보를 받아오고, `useLearningSession` 스토어를 동기화(Hydration)한 뒤 문제 화면으로 이동합니다.
- 종료하기: `finishSessionApi`를 호출하여 세션을 정리하고, 유저 정보를 갱신합니다.

### 3. API 및 스토어 연동

- 백엔드의 /sessions/active-session, /sessions/:id (GET) 엔드포인트와 연동되는 API 함수를 추가했습니다.
- 세션 복구 시 question, currentQuestionCount, remainedCredit 등의 상태를 스토어에 주입하도록 구현했습니다.

### 4. e2e 테스트 코드 수정
- 기존: learning 페이지 접속 시 바로 진행중인 세션이 있는지 확인하고 다이얼로그를 띄우는 시나리오
- 변경: 학습하기 버튼을 누르면 그 때 진행중인 세션이 있는지 확인하고 새로운 세션 생성/이어하기 모달 분기하는 시나리오로 수정

<br/>

## 📷 스크린샷


https://github.com/user-attachments/assets/600ae6bc-684e-44d1-a2ef-c3132a73386e




<img width="3071" height="1764" alt="image" src="https://github.com/user-attachments/assets/4fe9f18d-3ad2-4440-a551-81c5626df058" />
E2E 테스트 통과 확인
<br/>

## ✅ 체크리스트

- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `10분`
> 리뷰어에게 남기고 싶은 말)

### 커밋 메시지에서 #189 번 이슈에 관한 커밋들만 확인해주시면 될 것 같습니다!

### 🚧 아래 내용을 추가로 작업해서 커밋할 예정입니다.

#### 1. 세션 복구 로직 고도화 예정

현재 구현은 세션을 복구할 때 단순히 세션 메타데이터를 불러오고 질문을 다시 Pick 하는 방식입니다.

해당 세션에서 이미 답변을 제출한 기록이 있다면, 단순히 문제를 다시 보여주는 것이 아니라 가장 최근 답변의 '피드백 결과 화면'을 복구하여 보여주도록 로직을 개선할 예정입니다.

#### 2. '종료하기' 시 리워드 모달 노출 여부 (의견 요청)

현재 모달에서 '종료하기'를 선택하면 백엔드에 finish를 요청하고 User 스토어(크레딧 등)만 조용히 업데이트한 뒤 모달이 닫히도록 구현되어 있습니다.

여기서도 일반적인 학습 종료 시나리오와 동일하게 '리워드 모달(획득 경험치 등 표시)'을 띄워주는 것이 좋을까요? 아니면 현재처럼 조용히 종료하는 흐름이 나을지 의견 부탁드립니다.

<br/>

## 📄 추가 전달 사항
문제 해결과정은 wiki에 작성!! 토의를 하고 싶다면 discussion으로!

- 공유한 내용이나 반영된 내용은 wiki에 이어서 작성(사고나 작업의 변화를 보기 위해 기존의 내용 수정X)
