### PR TITLE
Fix/#194 딥다이브 평가 실패 개선

### DIFF
--- a/apps/be/prisma/schema.prisma
+++ b/apps/be/prisma/schema.prisma
@@ -116,13 +116,16 @@ model Question {
 
 model QuestionRubricItem {
   id           Int    @id @default(autoincrement())
-  questionId   Int    @map("question_id")
+  questionId   Int?   @map("question_id")
+  extraQuestionId Int? @map("extra_question_id")
   keywordsText String @map("keywords_text") @db.Text
   weight       Float  @db.Float
 
-  question Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  question Question? @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  extraQuestion ExtraQuestion? @relation(fields: [extraQuestionId], references: [id], onDelete: Cascade)
 
   @@index([questionId])
+  @@index([extraQuestionId])
   @@map("question_rubric_items")
 }
 
@@ -146,6 +149,7 @@ model ExtraQuestion {
   parentAnswer UserAnswer @relation("AnswerToExtraQuestion", fields: [parentAnswerId], references: [id], onDelete: Cascade)
 
   answers UserAnswer[] @relation("ExtraQuestionToAnswer")
+  rubricItems QuestionRubricItem[]
 
   @@index([sessionId])
   @@index([parentAnswerId])

--- a/apps/be/src/modules/assessment/assessment.repository.ts
+++ b/apps/be/src/modules/assessment/assessment.repository.ts
@@ -109,6 +109,14 @@ export class AssessmentRepository {
   }
 
   /**
+   * 답변을 삭제합니다.
+   * 연결된 평가 잡은 onDelete: Cascade로 함께 삭제됩니다.
+   */
+  deleteAnswerById(answerId: number): Promise<UserAnswer> {
+    return this.prisma.userAnswer.delete({ where: { id: answerId } });
+  }
+
+  /**
    * `answerId`로 단일 평가 잡을 조회합니다.
    *
    * Prisma 스키마에서 `AssessmentJob.answerId`는 `@unique`로 보장됩니다.

--- a/apps/be/src/modules/assessment/assessment.service.ts
+++ b/apps/be/src/modules/assessment/assessment.service.ts
@@ -91,12 +91,17 @@ export class AssessmentService {
           `Enqueue skipped (duplicate jobId). Treating as success. error=${message}`,
         );
       } else {
-        // 실제 실패는 DB 상태를 FAILED로 전파하고 503 반환
-        await this.repo.updateAssessmentJob(job.id, {
-          status: AssessmentStatus.FAILED,
-          error: message,
-          finishedAt: new Date(),
-        });
+        // 실제 실패는 답변/잡을 정리하고 503 반환
+        try {
+          await this.repo.deleteAnswerById(answer.id);
+          this.logger.warn(`Enqueue evaluate failed; cleaned up answer: answerId=${answer.id}`);
+        } catch (cleanupError: unknown) {
+          const cleanupMessage =
+            cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+          this.logger.error(
+            `Enqueue evaluate failed; cleanup failed: answerId=${answer.id} error=${cleanupMessage}`,
+          );
+        }
         this.logger.error(`Enqueue evaluate failed: ${message}`);
         throw new ServiceUnavailableException({
           code: 'ASSESSMENT_ENQUEUE_FAILED',

--- a/apps/be/src/modules/assessment/evaluation/application/evaluate.service.ts
+++ b/apps/be/src/modules/assessment/evaluation/application/evaluate.service.ts
@@ -34,11 +34,15 @@ export class EvaluateService {
     // 2) 질문 컨텍스트 추출(문항 내용/필수 포함 키워드)
     const question = extractQuestionContext(answer);
     const questionContent = question.content;
-    const questionId = question.id;
+    const questionId = answer.question?.id ?? null;
+    const extraQuestionId = answer.extraQuestion?.id ?? null;
     const questionSummary = questionContent.slice(0, 200);
 
     // 3) 문항에 대한 루브릭 조회
-    const rubric = (await this.evaluationRepo.getRubricByQuestionId(questionId)) ?? {
+    const rubric = (await this.evaluationRepo.getRubricByTarget({
+      questionId: questionId ?? undefined,
+      extraQuestionId: extraQuestionId ?? undefined,
+    })) ?? {
       items: [],
       scale: '0-2' as const,
     };

--- a/apps/be/src/modules/assessment/evaluation/application/rubric.service.ts
+++ b/apps/be/src/modules/assessment/evaluation/application/rubric.service.ts
@@ -13,20 +13,21 @@ export class RubricService {
   ) {}
   async create(answerId: number): Promise<Rubric> {
     // 답변에 연관된 문항 조회
-    const answerWithQuestion = await this.repo.findQuestionByAnswerId(answerId);
-    if (!answerWithQuestion) {
+    const context = await this.repo.findQuestionContextByAnswerId(answerId);
+    if (!context) {
       this.logger.error(`QUESTION_NOT_FOUND: answerId=${answerId} relation=null`);
       throw new Error('QUESTION_NOT_FOUND');
     }
 
-    const question = answerWithQuestion.content;
-    const questionId = answerWithQuestion.id;
+    const question = context.content;
+    const questionId = context.kind === 'question' ? context.id : undefined;
+    const extraQuestionId = context.kind === 'extraQuestion' ? context.id : undefined;
     this.logger.log(
-      `Rubric create: answerId=${answerId} questionId=${questionId} questionLen=${String(question ?? '').length}`,
+      `Rubric create: answerId=${answerId} ${context.kind}Id=${context.id} questionLen=${String(question ?? '').length}`,
     );
 
     // 1) 기존에 생성된 루브릭이 있는지 확인
-    const existingRubric = await this.repo.getRubricByQuestionId(questionId);
+    const existingRubric = await this.repo.getRubricByTarget({ questionId, extraQuestionId });
 
     // 2) 존재하면 재생성하지 않고 반환
     if (existingRubric) {
@@ -37,7 +38,7 @@ export class RubricService {
     const rubric = await this.rubricProvider.generate({ question });
 
     // 4) 생성된 루브릭을 DB에 저장(keywordsText에 description 저장됨)
-    await this.repo.saveRubric(questionId, JSON.stringify(rubric));
+    await this.repo.saveRubric({ questionId, extraQuestionId }, JSON.stringify(rubric));
 
     // 5) 루브릭 반환
     return rubric;

--- a/apps/be/src/modules/assessment/evaluation/evaluation.repository.ts
+++ b/apps/be/src/modules/assessment/evaluation/evaluation.repository.ts
@@ -8,19 +8,46 @@ import type { Rubric, RubricItem } from './dtos';
 export class EvaluationRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findQuestionByAnswerId(answerId: number) {
-    // answerId에 연결된 문항을 조회합니다.
+  async findQuestionContextByAnswerId(
+    answerId: number,
+  ): Promise<
+    | { kind: 'question'; id: number; content: string }
+    | { kind: 'extraQuestion'; id: number; content: string }
+    | null
+  > {
+    // answerId에 연결된 문항/꼬리문항 컨텍스트를 조회합니다.
     const answer = await this.prisma.userAnswer.findUnique({
       where: { id: answerId },
-      select: { question: true },
+      select: {
+        question: { select: { id: true, content: true } },
+        extraQuestion: { select: { id: true, content: true } },
+      },
     });
-    return answer?.question ?? null;
+    if (answer?.question) {
+      return { kind: 'question', id: answer.question.id, content: answer.question.content };
+    }
+    if (answer?.extraQuestion) {
+      return {
+        kind: 'extraQuestion',
+        id: answer.extraQuestion.id,
+        content: answer.extraQuestion.content,
+      };
+    }
+    return null;
   }
 
-  async getRubricByQuestionId(questionId: number): Promise<Rubric | null> {
-    // questionId에 해당하는 루브릭 항목들을 조회하여 Rubric 형태로 반환합니다.
+  async getRubricByTarget(params: {
+    questionId?: number;
+    extraQuestionId?: number;
+  }): Promise<Rubric | null> {
+    // questionId/extraQuestionId에 해당하는 루브릭 항목들을 조회하여 Rubric 형태로 반환합니다.
+    const { questionId, extraQuestionId } = params;
+    if (!questionId && !extraQuestionId) return null;
     const items = await this.prisma.questionRubricItem.findMany({
-      where: { questionId },
+      where: {
+        ...(questionId ? { questionId } : {}),
+        ...(extraQuestionId ? { extraQuestionId } : {}),
+      },
       orderBy: { id: 'asc' },
     });
     if (!items.length) return null;
@@ -44,9 +71,15 @@ export class EvaluationRepository {
     return { items: rubricItems, scale: '0-2' } as Rubric;
   }
 
-  async saveRubric(questionId: number, rubricContent: string) {
-    // questionId에 해당하는 루브릭을 항목 단위로 저장합니다.
+  async saveRubric(
+    params: { questionId?: number; extraQuestionId?: number },
+    rubricContent: string,
+  ) {
+    // questionId/extraQuestionId에 해당하는 루브릭을 항목 단위로 저장합니다.
     // rubricContent 는 JSON 문자열이어야 합니다.
+    const { questionId, extraQuestionId } = params;
+    if (!questionId && !extraQuestionId) throw new Error('RUBRIC_TARGET_REQUIRED');
+    if (questionId && extraQuestionId) throw new Error('RUBRIC_TARGET_AMBIGUOUS');
     let rubric: Rubric;
     const hasProp = <K extends string>(obj: unknown, prop: K): obj is Record<K, unknown> =>
       typeof obj === 'object' && obj !== null && prop in obj;
@@ -76,13 +109,19 @@ export class EvaluationRepository {
 
     await this.prisma.$transaction(async (tx) => {
       // 기존 항목 삭제 후 재삽입(간단/일관성)
-      await tx.questionRubricItem.deleteMany({ where: { questionId } });
+      await tx.questionRubricItem.deleteMany({
+        where: {
+          ...(questionId ? { questionId } : {}),
+          ...(extraQuestionId ? { extraQuestionId } : {}),
+        },
+      });
       if (!items.length) return;
       // 저장: description 문장을 keywordsText에 직접 보관(문장 단위 저장)
       for (const it of items) {
         await tx.questionRubricItem.create({
           data: {
-            questionId,
+            questionId: questionId ?? undefined,
+            extraQuestionId: extraQuestionId ?? undefined,
             keywordsText: String(it.description ?? ''),
             weight: Number(it.weight ?? 0.2),
           },

--- a/apps/be/src/modules/assessment/worker/stages/feedback.stage.ts
+++ b/apps/be/src/modules/assessment/worker/stages/feedback.stage.ts
@@ -114,6 +114,14 @@ export async function handleFeedbackStage(
       timestamp: new Date().toISOString(),
       error: message,
     });
+    try {
+      await repo.deleteAnswerById(answerId);
+      logger.warn(`[Feedback] cleanup answer: answerId=${answerId}`);
+    } catch (cleanupError: unknown) {
+      const cleanupMessage =
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      logger.error(`[Feedback] cleanup failed: answerId=${answerId} error=${cleanupMessage}`);
+    }
     throw e;
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- close #195

<br/>

## 🔍 작업 내용

### 1️⃣ Question / ExtraQuestion 공통 루브릭 지원

`QuestionRubricItem`이 문항(question) 또는 꼬리문항(extraQuestion) 중 **하나의 타겟**에만 연결되도록 구조를 확장했습니다.

- `QuestionRubricItem`에 `extraQuestionId Int?` 컬럼 추가
- `questionId` / `extraQuestionId` 중 **하나만 설정되도록 코드 레벨에서 보장**
- `@@index([extraQuestionId])` 추가
- Prisma relation 추가
  - `extraQuestion ExtraQuestion? @relation(...)`

#### Prisma 스키마 변경
- `schema.prisma`
  - `extraQuestionId` 컬럼 및 relation 추가
  - question / extraQuestion 중 하나만 설정되는 구조로 정리

#### 루브릭 조회 / 저장 로직 개선
- 답변(`answer`) → `question` / `extraQuestion` 컨텍스트를 구분하여 처리
- 루브릭 조회/저장 API를 공통 타겟 기반으로 통합

이제 deep-dive(꼬리질문) 문항에 대해서도 루브릭 생성 및 조회가 정상 동작합니다.

---

### 2️⃣ 평가 큐(enqueue) 실패 시 답변 정리 처리

평가 작업이 정상적으로 큐에 등록되지 못한 경우, **이미 생성된 답변 데이터가 남지 않도록 정리 로직을 추가**했습니다.

#### 처리 내용
- enqueue 실패 시 생성된 `Answer` 삭제
- `AssessmentJob`은 FK `onDelete: Cascade` 설정으로 함께 삭제됨

#### 적용 위치
- enqueue 실패 시 답변 삭제 로직 추가
  - `assessment.service.ts`
- 답변 삭제용 repository 메서드 추가
  - `assessment.repository.ts`

#### 참고
- **평가 수행 중(워커 단계) 에러가 발생한 경우에도 답변을 삭제하도록 처리 완료**

<br/>

## ✅ 체크리스트
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

<br/>

## 💬 리뷰 요구 사항
> 리뷰 예상 시간: `5분`  